### PR TITLE
Fix taskfile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -34,7 +34,8 @@ dist:
   desc: Builds binary and packs plugin
   cmds:
     - go build -o plugin
-    - mkdir dist/
+    - cmd: mkdir -p dist/
+      silent: true
     - tar -czf dist/matterpoll.tar.gz plugin.yaml plugin
     - rm plugin
 


### PR DESCRIPTION
This fixes an issue where the task would fail if `dist`already exists.