### PR TITLE
Fix bugs

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -24,7 +24,7 @@ func (p *MatterpollPlugin) OnActivate(api plugin.API) error {
 
 func (p *MatterpollPlugin) ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
 	input := ParseInput(args.Command)
-	if len(input) < 3 {
+	if len(input) < 2 {
 		return &model.CommandResponse{
 			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
 			Username:     `Matterpoll`,

--- a/plugin.go
+++ b/plugin.go
@@ -40,7 +40,7 @@ func (p *MatterpollPlugin) ExecuteCommand(args *model.CommandArgs) (*model.Comma
 	return &model.CommandResponse{
 		ResponseType: model.COMMAND_RESPONSE_TYPE_IN_CHANNEL,
 		Username:     `Matterpoll`,
-		Attachments: []*model.SlackAttachment{&model.SlackAttachment{
+		Attachments: []*model.SlackAttachment{{
 			AuthorName: `Matterpoll`,
 			Text:       input[0],
 			Actions:    attachList,

--- a/plugin.go
+++ b/plugin.go
@@ -8,11 +8,13 @@ import (
 	"github.com/mattermost/mattermost-server/plugin/rpcplugin"
 )
 
-type MatterpollPlugin struct{}
+type MatterpollPlugin struct {
+	api plugin.API
+}
 
 func (p *MatterpollPlugin) OnActivate(api plugin.API) error {
-	return api.RegisterCommand(&model.Command{
-		DisplayName:      `Matterpoll`,
+	p.api = api
+	return p.api.RegisterCommand(&model.Command{
 		Trigger:          `matterpoll`,
 		AutoComplete:     true,
 		AutoCompleteDesc: `Create a poll`,
@@ -22,11 +24,11 @@ func (p *MatterpollPlugin) OnActivate(api plugin.API) error {
 
 func (p *MatterpollPlugin) ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
 	input := ParseInput(args.Command)
-	if len(input) == 0 {
+	if len(input) < 3 {
 		return &model.CommandResponse{
 			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
 			Username:     `Matterpoll`,
-			Text:         `We need input. Try /matterpoll "Question" "Answer 1" "Answer 2"`,
+			Text:         `We need input. Try ` + "`" + `/matterpoll "Question" "Answer 1" "Answer 2"` + "`",
 		}, nil
 	}
 	attachList := []*model.PostAction{}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -37,31 +37,55 @@ func TestPluginExecuteCommand(t *testing.T) {
 }
 
 func TestPluginExecuteCommandHelp(t *testing.T) {
-	assert := assert.New(t)
 	p := &main.MatterpollPlugin{}
 
 	r, err := p.ExecuteCommand(&model.CommandArgs{
 		Command: `/matterpoll`,
 	})
 
-	assert.Nil(err)
+	assert.Nil(t, err)
+	isHelpResponce(t, r)
+}
+
+func TestPluginExecuteOneArgument(t *testing.T) {
+	p := &main.MatterpollPlugin{}
+
+	r, err := p.ExecuteCommand(&model.CommandArgs{
+		Command: `/matterpoll "abcd"`,
+	})
+	assert.Nil(t, err)
+	isHelpResponce(t, r)
+}
+
+func TestPluginExecuteTwoArguments(t *testing.T) {
+	p := &main.MatterpollPlugin{}
+
+	r, err := p.ExecuteCommand(&model.CommandArgs{
+		Command: `/matterpoll "abcd" "abcd"`,
+	})
+	assert.Nil(t, err)
+	isHelpResponce(t, r)
+}
+
+func isHelpResponce(t *testing.T, r *model.CommandResponse) {
+	assert := assert.New(t)
+
 	assert.NotNil(r)
 	assert.Equal(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, r.ResponseType)
 	assert.Equal(`Matterpoll`, r.Username)
-	assert.Equal(`We need input. Try /matterpoll "Question" "Answer 1" "Answer 2"`, r.Text)
+	assert.Equal(`We need input. Try `+"`"+`/matterpoll "Question" "Answer 1" "Answer 2"`+"`", r.Text)
 	assert.Nil(r.Attachments)
 }
 
 func TestPluginOnActivate(t *testing.T) {
 	api := &plugintest.API{}
 	api.On("RegisterCommand", &model.Command{
-		DisplayName:      `Matterpoll`,
 		Trigger:          `matterpoll`,
 		AutoComplete:     true,
 		AutoCompleteDesc: `Create a poll`,
 		AutoCompleteHint: `[Question] [Answer 1] [Answer 2]...`,
 	}).Return(nil)
-	//defer api.AssertExpectations(t)
+	defer api.AssertExpectations(t)
 
 	p := &main.MatterpollPlugin{}
 	p.OnActivate(api)

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -29,10 +29,10 @@ func TestPluginExecuteCommand(t *testing.T) {
 	assert.NotNil(r)
 	assert.Equal(model.COMMAND_RESPONSE_TYPE_IN_CHANNEL, r.ResponseType)
 	assert.Equal(`Matterpoll`, r.Username)
-	assert.Equal([]*model.SlackAttachment{&model.SlackAttachment{
+	assert.Equal([]*model.SlackAttachment{{
 		AuthorName: `Matterpoll`,
 		Text:       `Question`,
-		Actions:    []*model.PostAction{&model.PostAction{Name: `Answer 1`}, &model.PostAction{Name: `Answer 2`}},
+		Actions:    []*model.PostAction{{Name: `Answer 1`}, {Name: `Answer 2`}},
 	}}, r.Attachments)
 }
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -44,7 +44,7 @@ func TestPluginExecuteCommandHelp(t *testing.T) {
 	})
 
 	assert.Nil(t, err)
-	isHelpResponce(t, r)
+	assertHelpResponse(t, r)
 }
 
 func TestPluginExecuteOneArgument(t *testing.T) {
@@ -54,20 +54,10 @@ func TestPluginExecuteOneArgument(t *testing.T) {
 		Command: `/matterpoll "abcd"`,
 	})
 	assert.Nil(t, err)
-	isHelpResponce(t, r)
+	assertHelpResponse(t, r)
 }
 
-func TestPluginExecuteTwoArguments(t *testing.T) {
-	p := &main.MatterpollPlugin{}
-
-	r, err := p.ExecuteCommand(&model.CommandArgs{
-		Command: `/matterpoll "abcd" "abcd"`,
-	})
-	assert.Nil(t, err)
-	isHelpResponce(t, r)
-}
-
-func isHelpResponce(t *testing.T, r *model.CommandResponse) {
+func assertHelpResponse(t *testing.T, r *model.CommandResponse) {
 	assert := assert.New(t)
 
 	assert.NotNil(r)


### PR DESCRIPTION
This PR fixes a couple of bugs:
- We now store `plugin.API` to perform action with it. This will be needed in other PRs.
- If the user provides less then two arguments (e.g. `/matterpoll "Question" "Answer 1"`, a help message will be posted. This PR also adds tests for this chase.
- The help test is now properly formated.