### PR TITLE
Add CreatedAt field to Poll

### DIFF
--- a/build/manifest/Gopkg.toml
+++ b/build/manifest/Gopkg.toml
@@ -1,3 +1,8 @@
+[prune]
+  non-go = true
+  go-tests = true
+  unused-packages = true
+
 [[constraint]]
   name = "github.com/mattermost/mattermost-server"
   version = "~5.2.0"
@@ -5,8 +10,3 @@
 [[constraint]]
   name = "github.com/pkg/errors"
   version = "0.8.0"
-
-[prune]
-  non-go = true
-  go-tests = true
-  unused-packages = true

--- a/server/Gopkg.lock
+++ b/server/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:d83a0c69ae2f09a89d2c2a05d1158c522947d681c26cd5a0c25a39ca8ed031a9"
+  name = "github.com/bouk/monkey"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "5df1f207ff77e025801505ae4d903133a0b4353f"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -495,6 +503,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/bouk/monkey",
     "github.com/mattermost/mattermost-server/model",
     "github.com/mattermost/mattermost-server/plugin",
     "github.com/mattermost/mattermost-server/plugin/plugintest",

--- a/server/Gopkg.toml
+++ b/server/Gopkg.toml
@@ -1,12 +1,16 @@
+[prune]
+  non-go = true
+  go-tests = true
+  unused-packages = true
+
 [[constraint]]
   name = "github.com/mattermost/mattermost-server"
   branch = "master"
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "~1.2"
+  version = "~1.2.0"
 
-[prune]
-  non-go = true
-  go-tests = true
-  unused-packages = true
+[[constraint]]
+  name = "github.com/bouk/monkey"
+  version = "~1.0.0"

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/bouk/monkey"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin/plugintest"
 	"github.com/stretchr/testify/assert"
@@ -15,6 +16,7 @@ func TestPluginExecuteCommand(t *testing.T) {
 	trigger := "poll"
 	idGen := new(MockPollIDGenerator)
 	poll := Poll{
+		CreatedAt:         1234567890,
 		Creator:           "userID1",
 		DataSchemaVersion: "v1",
 		Question:          "Question",
@@ -165,6 +167,9 @@ func TestPluginExecuteCommand(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
+			patch := monkey.Patch(model.GetMillis, func() int64 { return 1234567890 })
+			defer patch.Unpatch()
+
 			idGen := new(MockPollIDGenerator)
 			p := &MatterpollPlugin{
 				idGen: idGen,

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 var samplePoll = Poll{
+	CreatedAt:         1234567890,
 	Creator:           "userID1",
 	DataSchemaVersion: "v1",
 	Question:          "Question",
@@ -20,6 +21,7 @@ var samplePoll = Poll{
 }
 
 var samplePollWithVotes = Poll{
+	CreatedAt:         1234567890,
 	Creator:           "userID1",
 	DataSchemaVersion: "v1",
 	Question:          "Question",

--- a/server/poll.go
+++ b/server/poll.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Poll struct {
+	CreatedAt         int64
 	Creator           string
 	DataSchemaVersion string
 	Question          string
@@ -21,7 +22,7 @@ type AnswerOption struct {
 }
 
 func NewPoll(creator string, question string, answerOptions []string) *Poll {
-	p := Poll{Creator: creator, DataSchemaVersion: CurrentDataSchemaVersion, Question: question}
+	p := Poll{CreatedAt: model.GetMillis(), Creator: creator, DataSchemaVersion: CurrentDataSchemaVersion, Question: question}
 	for _, o := range answerOptions {
 		p.AnswerOptions = append(p.AnswerOptions, &AnswerOption{Answer: o})
 	}

--- a/server/poll_test.go
+++ b/server/poll_test.go
@@ -3,8 +3,29 @@ package main
 import (
 	"testing"
 
+	"github.com/bouk/monkey"
+	"github.com/mattermost/mattermost-server/model"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestNewPoll(t *testing.T) {
+	assert := assert.New(t)
+	patch := monkey.Patch(model.GetMillis, func() int64 { return 1234567890 })
+	defer patch.Unpatch()
+
+	creator := model.NewRandomString(10)
+	question := model.NewRandomString(10)
+	answerOptions := []string{model.NewRandomString(10), model.NewRandomString(10), model.NewRandomString(10)}
+	p := NewPoll(creator, question, answerOptions)
+
+	assert.Equal(int64(1234567890), p.CreatedAt)
+	assert.Equal(creator, p.Creator)
+	assert.Equal(CurrentDataSchemaVersion, p.DataSchemaVersion)
+	assert.Equal(question, p.Question)
+	assert.Equal(&AnswerOption{Answer: answerOptions[0], Voter: nil}, p.AnswerOptions[0])
+	assert.Equal(&AnswerOption{Answer: answerOptions[1], Voter: nil}, p.AnswerOptions[1])
+	assert.Equal(&AnswerOption{Answer: answerOptions[2], Voter: nil}, p.AnswerOptions[2])
+}
 
 func TestEncodeDecode(t *testing.T) {
 	p1 := &Poll{


### PR DESCRIPTION
This PR add `CreatedAt int64` to `Poll`. I chose `int64`because its used my Mattermost.

Testing this was a lit hard. I'm using https://github.com/bouk/monkey to replace the calls to `GetMillis()` by a static number. This ain't pretty, but it does the job. Otherwise we would have to do something like adding `TimeGenerator` to `MatterpollPlugin`.

I also fixed some Gopkg problems.

Fixes #43 