### PR TITLE
Serve user icon from local assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ bundle:
 	rm -rf dist/
 	mkdir -p dist/$(PLUGIN_ID)
 	cp $(MANIFEST_FILE) dist/$(PLUGIN_ID)/
+	cp assets/logo_dark.png dist/$(PLUGIN_ID)/
 ifneq ($(HAS_SERVER),)
 	mkdir -p dist/$(PLUGIN_ID)/server/dist;
 	cp -r server/dist/* dist/$(PLUGIN_ID)/server/dist/;

--- a/server/command.go
+++ b/server/command.go
@@ -8,10 +8,13 @@ import (
 )
 
 const (
-	responseIconURL  = "https://raw.githubusercontent.com/matterpoll/matterpoll/master/assets/logo_dark.png"
+	// Parameter: SiteURL, PluginId
+	responseIconURL  = "%s/plugins/%s/logo_dark.png"
 	responseUsername = "Matterpoll"
 
-	commandHelpTextFormat   = "To create a poll with the answer options \"Yes\" and \"No\" type `/%s \"Question\"`.\nYou can customise the options by typing `/%s \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\"` "
+	// Parameter: Trigger
+	commandHelpTextFormat = "To create a poll with the answer options \"Yes\" and \"No\" type `/%s \"Question\"`.\nYou can customise the options by typing `/%s \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\"`"
+	// Parameter: Trigger, Trigger
 	commandInputErrorFormat = "Invalid Input. Try `/%s \"Question\"` or `/%s \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\"`"
 	commandGenericError     = "Something went bad. Please try again later."
 )
@@ -56,7 +59,7 @@ func getCommandResponse(responseType, text string, attachments []*model.SlackAtt
 		ResponseType: responseType,
 		Text:         text,
 		Username:     responseUsername,
-		IconURL:      responseIconURL,
+		IconURL:      fmt.Sprintf(responseIconURL, "http://localhost:8065", PluginId),
 		Type:         model.POST_DEFAULT,
 		Attachments:  attachments,
 	}

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -196,7 +196,7 @@ func TestPluginExecuteCommand(t *testing.T) {
 
 			assert.Equal(model.POST_DEFAULT, r.Type)
 			assert.Equal(responseUsername, r.Username)
-			assert.Equal(responseIconURL, r.IconURL)
+			assert.Equal(fmt.Sprintf(responseIconURL, siteURL, PluginId), r.IconURL)
 			assert.Equal(test.ExpectedResponseType, r.ResponseType)
 			assert.Equal(test.ExpectedText, r.Text)
 			assert.Equal(test.ExpectedAttachments, r.Attachments)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin"
@@ -39,6 +40,8 @@ func (p *MatterpollPlugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r
 	switch {
 	case r.URL.Path == "/":
 		p.handleInfo(w, r)
+	case r.URL.Path == "/logo_dark.png":
+		http.ServeFile(w, r, strings.TrimPrefix(r.RequestURI, "/"))
 	case voteRoute.MatchString(r.URL.Path):
 		p.handleVote(w, r)
 	case endPollRoute.MatchString(r.URL.Path):

--- a/server/poll.go
+++ b/server/poll.go
@@ -66,7 +66,7 @@ func (p *Poll) ToPostActions(siteURL, pollID, authorName string) []*model.SlackA
 }
 
 func (p *Poll) ToCommandResponse(siteURL, pollID, authorName string) *model.CommandResponse {
-	return getCommandResponse(model.COMMAND_RESPONSE_TYPE_IN_CHANNEL, "", p.ToPostActions(siteURL, pollID, authorName))
+	return getCommandResponse(model.COMMAND_RESPONSE_TYPE_IN_CHANNEL, "", siteURL, p.ToPostActions(siteURL, pollID, authorName))
 }
 
 func (p *Poll) ToEndPollPost(authorName string, convert func(string) (string, *model.AppError)) (*model.Post, *model.AppError) {


### PR DESCRIPTION
Todo:
- [x] Use in `getCommandResponse()`
- [x] Fix tests
- [x] Add tests

Based on https://github.com/matterpoll/matterpoll/pull/33/commits/05319b97e38409b62c567901e0a19e63c00dc25b

Fixes #17 