### PR TITLE
Sync read and write to config

### DIFF
--- a/server/Gopkg.lock
+++ b/server/Gopkg.lock
@@ -429,6 +429,7 @@
     "github.com/mattermost/mattermost-server/model",
     "github.com/mattermost/mattermost-server/plugin",
     "github.com/mattermost/mattermost-server/plugin/plugintest",
+    "github.com/pkg/errors",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/mock",
     "github.com/stretchr/testify/require",

--- a/server/Gopkg.toml
+++ b/server/Gopkg.toml
@@ -18,3 +18,7 @@
 [[constraint]]
   name = "github.com/gorilla/mux"
   version = "~1.6.0"
+
+[[constraint]]
+  name = "github.com/pkg/errors"
+  version = "~0.8.0"

--- a/server/api.go
+++ b/server/api.go
@@ -29,6 +29,7 @@ const (
 	deletePollSuccess           = "Succefully deleted the poll."
 )
 
+// InitAPI initializes the REST API
 func (p *MatterpollPlugin) InitAPI() *mux.Router {
 	r := mux.NewRouter()
 	r.HandleFunc("/", p.handleInfo).Methods("GET")

--- a/server/command.go
+++ b/server/command.go
@@ -36,7 +36,7 @@ func (p *MatterpollPlugin) ExecuteCommand(c *plugin.Context, args *model.Command
 		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, msg, siteURL, nil), nil
 	}
 	if len(o) == 1 {
-		msg := fmt.Sprintf(commandInputErrorFormat, p.Config.Trigger)
+		msg := fmt.Sprintf(commandInputErrorFormat, config.Trigger)
 		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, msg, siteURL, nil), nil
 	}
 

--- a/server/command.go
+++ b/server/command.go
@@ -28,15 +28,15 @@ const (
 func (p *MatterpollPlugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
 	creatorID := args.UserId
 	siteURL := *p.ServerConfig.ServiceSettings.SiteURL
-	config := p.getConfiguration()
+	configuration := p.getConfiguration()
 
-	q, o, s := ParseInput(args.Command, config.Trigger)
+	q, o, s := ParseInput(args.Command, configuration.Trigger)
 	if q == "" || q == "help" {
-		msg := fmt.Sprintf(commandHelpTextFormat, config.Trigger)
+		msg := fmt.Sprintf(commandHelpTextFormat, configuration.Trigger)
 		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, msg, siteURL, nil), nil
 	}
 	if len(o) == 1 {
-		msg := fmt.Sprintf(commandInputErrorFormat, config.Trigger)
+		msg := fmt.Sprintf(commandInputErrorFormat, configuration.Trigger)
 		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, msg, siteURL, nil), nil
 	}
 

--- a/server/command.go
+++ b/server/command.go
@@ -24,13 +24,15 @@ const (
 	commandGenericError     = "Something went bad. Please try again later."
 )
 
+// ExecuteCommand parses a given input and creates a poll if the input is correct
 func (p *MatterpollPlugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
 	creatorID := args.UserId
 	siteURL := *p.ServerConfig.ServiceSettings.SiteURL
+	config := p.getConfiguration()
 
-	q, o, s := ParseInput(args.Command, p.Config.Trigger)
+	q, o, s := ParseInput(args.Command, config.Trigger)
 	if q == "" || q == "help" {
-		msg := fmt.Sprintf(commandHelpTextFormat, p.Config.Trigger)
+		msg := fmt.Sprintf(commandHelpTextFormat, config.Trigger)
 		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, msg, siteURL, nil), nil
 	}
 	if len(o) == 1 {

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -227,7 +227,8 @@ func TestPluginExecuteCommand(t *testing.T) {
 			api := test.SetupAPI(&plugintest.API{})
 			defer api.AssertExpectations(t)
 			p := setupTestPlugin(t, api, samplesiteURL)
-			p.Config.Trigger = trigger
+			p.configuration.Trigger = trigger
+
 			patch1 := monkey.Patch(model.GetMillis, func() int64 { return 1234567890 })
 			patch2 := monkey.Patch(model.NewId, func() string { return samplePollID })
 			defer patch1.Unpatch()

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -48,7 +48,7 @@ func TestPluginExecuteCommand(t *testing.T) {
 		},
 		"Just question": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
-				api.On("KVSet", samplePollID, samplePoll_twoOptions.Encode()).Return(nil)
+				api.On("KVSet", samplePollID, samplePollTwoOptions.Encode()).Return(nil)
 				api.On("GetUser", "userID1").Return(&model.User{FirstName: "John", LastName: "Doe"}, nil)
 				api.On("LogDebug", GetMockArgumentsWithType("string", 3)...).Return()
 				return api
@@ -65,25 +65,25 @@ func TestPluginExecuteCommand(t *testing.T) {
 					Name: "Yes",
 					Type: model.POST_ACTION_TYPE_BUTTON,
 					Integration: &model.PostActionIntegration{
-						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/vote/0", samplesiteURL, PluginId, CurrentApiVersion, samplePollID),
+						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/vote/0", samplesiteURL, PluginId, CurrentAPIVersion, samplePollID),
 					},
 				}, {
 					Name: "No",
 					Type: model.POST_ACTION_TYPE_BUTTON,
 					Integration: &model.PostActionIntegration{
-						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/vote/1", samplesiteURL, PluginId, CurrentApiVersion, samplePollID),
+						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/vote/1", samplesiteURL, PluginId, CurrentAPIVersion, samplePollID),
 					},
 				}, {
 					Name: "Delete Poll",
 					Type: model.POST_ACTION_TYPE_BUTTON,
 					Integration: &model.PostActionIntegration{
-						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/delete", samplesiteURL, PluginId, CurrentApiVersion, samplePollID),
+						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/delete", samplesiteURL, PluginId, CurrentAPIVersion, samplePollID),
 					},
 				}, {
 					Name: "End Poll",
 					Type: model.POST_ACTION_TYPE_BUTTON,
 					Integration: &model.PostActionIntegration{
-						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/end", samplesiteURL, PluginId, CurrentApiVersion, samplePollID),
+						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/end", samplesiteURL, PluginId, CurrentAPIVersion, samplePollID),
 					}},
 				},
 			}},
@@ -107,31 +107,31 @@ func TestPluginExecuteCommand(t *testing.T) {
 					Name: "Answer 1",
 					Type: model.POST_ACTION_TYPE_BUTTON,
 					Integration: &model.PostActionIntegration{
-						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/vote/0", samplesiteURL, PluginId, CurrentApiVersion, samplePollID),
+						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/vote/0", samplesiteURL, PluginId, CurrentAPIVersion, samplePollID),
 					},
 				}, {
 					Name: "Answer 2",
 					Type: model.POST_ACTION_TYPE_BUTTON,
 					Integration: &model.PostActionIntegration{
-						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/vote/1", samplesiteURL, PluginId, CurrentApiVersion, samplePollID),
+						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/vote/1", samplesiteURL, PluginId, CurrentAPIVersion, samplePollID),
 					},
 				}, {
 					Name: "Answer 3",
 					Type: model.POST_ACTION_TYPE_BUTTON,
 					Integration: &model.PostActionIntegration{
-						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/vote/2", samplesiteURL, PluginId, CurrentApiVersion, samplePollID),
+						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/vote/2", samplesiteURL, PluginId, CurrentAPIVersion, samplePollID),
 					},
 				}, {
 					Name: "Delete Poll",
 					Type: model.POST_ACTION_TYPE_BUTTON,
 					Integration: &model.PostActionIntegration{
-						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/delete", samplesiteURL, PluginId, CurrentApiVersion, samplePollID),
+						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/delete", samplesiteURL, PluginId, CurrentAPIVersion, samplePollID),
 					},
 				}, {
 					Name: "End Poll",
 					Type: model.POST_ACTION_TYPE_BUTTON,
 					Integration: &model.PostActionIntegration{
-						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/end", samplesiteURL, PluginId, CurrentApiVersion, samplePollID),
+						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/end", samplesiteURL, PluginId, CurrentAPIVersion, samplePollID),
 					},
 				},
 				},
@@ -159,31 +159,31 @@ func TestPluginExecuteCommand(t *testing.T) {
 					Name: "Answer 1 (0)",
 					Type: model.POST_ACTION_TYPE_BUTTON,
 					Integration: &model.PostActionIntegration{
-						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/vote/0", samplesiteURL, PluginId, CurrentApiVersion, samplePollID),
+						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/vote/0", samplesiteURL, PluginId, CurrentAPIVersion, samplePollID),
 					},
 				}, {
 					Name: "Answer 2 (0)",
 					Type: model.POST_ACTION_TYPE_BUTTON,
 					Integration: &model.PostActionIntegration{
-						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/vote/1", samplesiteURL, PluginId, CurrentApiVersion, samplePollID),
+						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/vote/1", samplesiteURL, PluginId, CurrentAPIVersion, samplePollID),
 					},
 				}, {
 					Name: "Answer 3 (0)",
 					Type: model.POST_ACTION_TYPE_BUTTON,
 					Integration: &model.PostActionIntegration{
-						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/vote/2", samplesiteURL, PluginId, CurrentApiVersion, samplePollID),
+						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/vote/2", samplesiteURL, PluginId, CurrentAPIVersion, samplePollID),
 					},
 				}, {
 					Name: "Delete Poll",
 					Type: model.POST_ACTION_TYPE_BUTTON,
 					Integration: &model.PostActionIntegration{
-						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/delete", samplesiteURL, PluginId, CurrentApiVersion, samplePollID),
+						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/delete", samplesiteURL, PluginId, CurrentAPIVersion, samplePollID),
 					},
 				}, {
 					Name: "End Poll",
 					Type: model.POST_ACTION_TYPE_BUTTON,
 					Integration: &model.PostActionIntegration{
-						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/end", samplesiteURL, PluginId, CurrentApiVersion, samplePollID),
+						URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/end", samplesiteURL, PluginId, CurrentAPIVersion, samplePollID),
 					},
 				},
 				},

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -1,31 +1,70 @@
 package main
 
-import "errors"
+import (
+	"github.com/pkg/errors"
+)
 
+// Config captures the plugin's external configuration as exposed in the Mattermost server
+// configuration, as well as values computed from the configuration. Any public fields will be
+// deserialized from the Mattermost server configuration in OnConfigurationChange.
 type Config struct {
 	Trigger string
 }
 
+// OnConfigurationChange loads the plugin configuration, validates it and saves it.
 func (p *MatterpollPlugin) OnConfigurationChange() error {
-	c := &Config{}
-	if err := p.API.LoadPluginConfiguration(c); err != nil {
-		return err
+	config := new(Config)
+
+	if err := p.API.LoadPluginConfiguration(config); err != nil {
+		return errors.Wrap(err, "failed to load plugin configuration")
 	}
 
-	if c.Trigger == "" {
+	if config.Trigger == "" {
 		return errors.New("Empty trigger not allowed")
 	}
 
 	if p.Config != nil {
 		if err := p.API.UnregisterCommand("", p.Config.Trigger); err != nil {
-			return err
+			return errors.Wrap(err, "failed to unregister old command")
 		}
 	}
-	if err := p.API.RegisterCommand(getCommand(c.Trigger)); err != nil {
-		return err
+	if err := p.API.RegisterCommand(getCommand(config.Trigger)); err != nil {
+		return errors.Wrap(err, "failed to register new command")
 	}
 
 	p.ServerConfig = p.API.GetConfig()
-	p.Config = c
+	p.setConfiguration(config)
 	return nil
+}
+
+// getConfiguration retrieves the active configuration under lock, making it safe to use
+// concurrently. The active configuration may change underneath the client of this method, but
+// the struct returned by this API call is considered immutable.
+func (p *MatterpollPlugin) getConfiguration() *Config {
+	p.configurationLock.RLock()
+	defer p.configurationLock.RUnlock()
+
+	if p.Config == nil {
+		return &Config{}
+	}
+	return p.Config
+}
+
+// setConfiguration replaces the active configuration under lock.
+//
+// Do not call setConfiguration while holding the configurationLock, as sync.Mutex is not
+// reentrant. In particular, avoid using the plugin API entirely, as this may in turn trigger a
+// hook back into the plugin. If that hook attempts to acquire this lock, a deadlock may occur.
+//
+// This method panics if setConfiguration is called with the existing configuration. This almost
+// certainly means that the configuration was modified without being cloned and may result in
+// an unsafe access.
+func (p *MatterpollPlugin) setConfiguration(config *Config) {
+	p.configurationLock.Lock()
+	defer p.configurationLock.Unlock()
+
+	if config != nil && p.Config == config {
+		panic("setConfiguration called with the existing configuration")
+	}
+	p.Config = config
 }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -14,6 +14,7 @@ type configuration struct {
 // OnConfigurationChange loads the plugin configuration, validates it and saves it.
 func (p *MatterpollPlugin) OnConfigurationChange() error {
 	configuration := new(configuration)
+	oldConfiguration := p.getConfiguration()
 
 	if err := p.API.LoadPluginConfiguration(configuration); err != nil {
 		return errors.Wrap(err, "failed to load plugin configuration")
@@ -23,8 +24,8 @@ func (p *MatterpollPlugin) OnConfigurationChange() error {
 		return errors.New("Empty trigger not allowed")
 	}
 
-	if p.getConfiguration().Trigger != "" {
-		if err := p.API.UnregisterCommand("", p.getConfiguration().Trigger); err != nil {
+	if oldConfiguration.Trigger != "" {
+		if err := p.API.UnregisterCommand("", oldConfiguration.Trigger); err != nil {
 			return errors.Wrap(err, "failed to unregister old command")
 		}
 	}

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -12,12 +12,12 @@ import (
 
 func TestOnConfigurationChange(t *testing.T) {
 	for name, test := range map[string]struct {
-		SetupAPI       func(*plugintest.API) *plugintest.API
-		Config         *configuration
-		ExpectedConfig *configuration
-		ShouldError    bool
+		SetupAPI              func(*plugintest.API) *plugintest.API
+		Configuration         *configuration
+		ExpectedConfiguration *configuration
+		ShouldError           bool
 	}{
-		"Load and save succesfull, with old config": {
+		"Load and save succesfull, with old configuration": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
 				api.On("LoadPluginConfiguration", mock.AnythingOfType("*main.configuration")).Return(nil).Run(func(args mock.Arguments) {
 					arg := args.Get(0).(*configuration)
@@ -28,11 +28,11 @@ func TestOnConfigurationChange(t *testing.T) {
 				api.On("GetConfig").Return(&model.Config{})
 				return api
 			},
-			Config:         &configuration{Trigger: "oldTrigger"},
-			ExpectedConfig: &configuration{Trigger: "poll"},
-			ShouldError:    false,
+			Configuration:         &configuration{Trigger: "oldTrigger"},
+			ExpectedConfiguration: &configuration{Trigger: "poll"},
+			ShouldError:           false,
 		},
-		"Load and save succesfull, without old config": {
+		"Load and save succesfull, without old configuration": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
 				api.On("LoadPluginConfiguration", mock.AnythingOfType("*main.configuration")).Return(nil).Run(func(args mock.Arguments) {
 					arg := args.Get(0).(*configuration)
@@ -42,18 +42,18 @@ func TestOnConfigurationChange(t *testing.T) {
 				api.On("GetConfig").Return(&model.Config{})
 				return api
 			},
-			Config:         nil,
-			ExpectedConfig: &configuration{Trigger: "poll"},
-			ShouldError:    false,
+			Configuration:         nil,
+			ExpectedConfiguration: &configuration{Trigger: "poll"},
+			ShouldError:           false,
 		},
 		"LoadPluginConfiguration fails": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
 				api.On("LoadPluginConfiguration", mock.AnythingOfType("*main.configuration")).Return(errors.New("LoadPluginConfiguration failed"))
 				return api
 			},
-			Config:         &configuration{Trigger: "oldTrigger"},
-			ExpectedConfig: &configuration{Trigger: "oldTrigger"},
-			ShouldError:    true,
+			Configuration:         &configuration{Trigger: "oldTrigger"},
+			ExpectedConfiguration: &configuration{Trigger: "oldTrigger"},
+			ShouldError:           true,
 		},
 		"Load empty trigger": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
@@ -63,9 +63,9 @@ func TestOnConfigurationChange(t *testing.T) {
 				})
 				return api
 			},
-			Config:         &configuration{Trigger: "oldTrigger"},
-			ExpectedConfig: &configuration{Trigger: "oldTrigger"},
-			ShouldError:    true,
+			Configuration:         &configuration{Trigger: "oldTrigger"},
+			ExpectedConfiguration: &configuration{Trigger: "oldTrigger"},
+			ShouldError:           true,
 		},
 		"UnregisterCommand fails": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
@@ -76,9 +76,9 @@ func TestOnConfigurationChange(t *testing.T) {
 				api.On("UnregisterCommand", "", "oldTrigger").Return(errors.New("UnregisterCommand failed"))
 				return api
 			},
-			Config:         &configuration{Trigger: "oldTrigger"},
-			ExpectedConfig: &configuration{Trigger: "oldTrigger"},
-			ShouldError:    true,
+			Configuration:         &configuration{Trigger: "oldTrigger"},
+			ExpectedConfiguration: &configuration{Trigger: "oldTrigger"},
+			ShouldError:           true,
 		},
 		"RegisterCommand fails": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
@@ -90,9 +90,9 @@ func TestOnConfigurationChange(t *testing.T) {
 				api.On("RegisterCommand", getCommand("poll")).Return(errors.New("RegisterCommand failed"))
 				return api
 			},
-			Config:         &configuration{Trigger: "oldTrigger"},
-			ExpectedConfig: &configuration{Trigger: "oldTrigger"},
-			ShouldError:    true,
+			Configuration:         &configuration{Trigger: "oldTrigger"},
+			ExpectedConfiguration: &configuration{Trigger: "oldTrigger"},
+			ShouldError:           true,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -101,10 +101,10 @@ func TestOnConfigurationChange(t *testing.T) {
 			api := test.SetupAPI(&plugintest.API{})
 			defer api.AssertExpectations(t)
 			p := setupTestPlugin(t, api, samplesiteURL)
-			p.setConfiguration(test.Config)
+			p.setConfiguration(test.Configuration)
 
 			err := p.OnConfigurationChange()
-			assert.Equal(test.ExpectedConfig, p.getConfiguration())
+			assert.Equal(test.ExpectedConfiguration, p.getConfiguration())
 			if test.ShouldError {
 				assert.NotNil(err)
 			} else {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -17,24 +17,21 @@ type MatterpollPlugin struct {
 	// configurationLock synchronizes access to the configuration.
 	configurationLock sync.RWMutex
 
-	// Config is the active plugin configuration. Consult getConfiguration and
+	// configuration is the active plugin configuration. Consult getConfiguration and
 	// setConfiguration for usage.
-	Config       *Config
-	ServerConfig *model.Config
+	configuration *configuration
+	ServerConfig  *model.Config
 }
 
 // OnActivate ensures a configuration is set and initalises the API
 func (p *MatterpollPlugin) OnActivate() error {
-	if p.Config == nil {
-		return errors.New("Config empty")
-	}
 	p.router = p.InitAPI()
 	return nil
 }
 
 // OnDeactivate unregisters the command
 func (p *MatterpollPlugin) OnDeactivate() error {
-	err := p.API.UnregisterCommand("", p.Config.Trigger)
+	err := p.API.UnregisterCommand("", p.getConfiguration().Trigger)
 	if err != nil {
 		return errors.Wrap(err, "failed to dectivate command")
 	}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -1,20 +1,29 @@
 package main
 
 import (
-	"errors"
+	"sync"
 
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin"
+	"github.com/pkg/errors"
 )
 
+// MatterpollPlugin is the object to run the plugin
 type MatterpollPlugin struct {
 	plugin.MattermostPlugin
-	router       *mux.Router
+	router *mux.Router
+
+	// configurationLock synchronizes access to the configuration.
+	configurationLock sync.RWMutex
+
+	// Config is the active plugin configuration. Consult getConfiguration and
+	// setConfiguration for usage.
 	Config       *Config
 	ServerConfig *model.Config
 }
 
+// OnActivate ensures a configuration is set and initalises the API
 func (p *MatterpollPlugin) OnActivate() error {
 	if p.Config == nil {
 		return errors.New("Config empty")
@@ -23,10 +32,16 @@ func (p *MatterpollPlugin) OnActivate() error {
 	return nil
 }
 
+// OnDeactivate unregisters the command
 func (p *MatterpollPlugin) OnDeactivate() error {
-	return p.API.UnregisterCommand("", p.Config.Trigger)
+	err := p.API.UnregisterCommand("", p.Config.Trigger)
+	if err != nil {
+		return errors.Wrap(err, "failed to dectivate command")
+	}
+	return nil
 }
 
+// ConvertUserIDToDisplayName returns the display name to a given user ID
 func (p *MatterpollPlugin) ConvertUserIDToDisplayName(userID string) (string, *model.AppError) {
 	user, err := p.API.GetUser(userID)
 	if err != nil {
@@ -37,6 +52,7 @@ func (p *MatterpollPlugin) ConvertUserIDToDisplayName(userID string) (string, *m
 	return displayName, nil
 }
 
+// ConvertCreatorIDToDisplayName returns the display name to a given user ID of a poll creator
 func (p *MatterpollPlugin) ConvertCreatorIDToDisplayName(creatorID string) (string, *model.AppError) {
 	user, err := p.API.GetUser(creatorID)
 	if err != nil {
@@ -46,6 +62,7 @@ func (p *MatterpollPlugin) ConvertCreatorIDToDisplayName(creatorID string) (stri
 	return displayName, nil
 }
 
+// HasPermission checks if a given user has the permission to end or delete a given poll
 func (p *MatterpollPlugin) HasPermission(poll *Poll, issuerID string) (bool, *model.AppError) {
 	if issuerID == poll.Creator {
 		return true, nil

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -41,7 +41,7 @@ var samplePollWithVotes = Poll{
 	},
 }
 
-var samplePoll_twoOptions = Poll{
+var samplePollTwoOptions = Poll{
 	CreatedAt:         1234567890,
 	Creator:           "userID1",
 	DataSchemaVersion: "v1",
@@ -70,31 +70,47 @@ func setupTestPlugin(t *testing.T, api *plugintest.API, siteURL string) *Matterp
 }
 
 func TestPluginOnActivate(t *testing.T) {
-	p := &MatterpollPlugin{
-		Config: &Config{},
-	}
-	err := p.OnActivate()
-	assert.Nil(t, err)
-}
+	t.Run("all fine", func(t *testing.T) {
+		p := &MatterpollPlugin{
+			Config: &Config{
+				Trigger: "poll",
+			},
+		}
+		err := p.OnActivate()
+		assert.Nil(t, err)
+	})
 
-func TestPluginOnActivateEmptyConfig(t *testing.T) {
-	p := &MatterpollPlugin{}
-	err := p.OnActivate()
-	assert.NotNil(t, err)
+	t.Run("empty config", func(t *testing.T) {
+		p := &MatterpollPlugin{}
+		err := p.OnActivate()
+		assert.NotNil(t, err)
+	})
 }
 
 func TestPluginOnDeactivate(t *testing.T) {
-	api := &plugintest.API{}
-	p := setupTestPlugin(t, api, samplesiteURL)
-	api.On("UnregisterCommand", "", p.Config.Trigger).Return(nil)
-	defer api.AssertExpectations(t)
+	t.Run("all fine", func(t *testing.T) {
+		api := &plugintest.API{}
+		p := setupTestPlugin(t, api, samplesiteURL)
+		api.On("UnregisterCommand", "", p.Config.Trigger).Return(nil)
+		defer api.AssertExpectations(t)
 
-	err := p.OnDeactivate()
-	assert.Nil(t, err)
+		err := p.OnDeactivate()
+		assert.Nil(t, err)
+	})
+
+	t.Run("UnregisterCommand fails", func(t *testing.T) {
+		api := &plugintest.API{}
+		p := setupTestPlugin(t, api, samplesiteURL)
+		api.On("UnregisterCommand", "", p.Config.Trigger).Return(&model.AppError{})
+		defer api.AssertExpectations(t)
+
+		err := p.OnDeactivate()
+		assert.NotNil(t, err)
+	})
 }
 
 func GetMockArgumentsWithType(typeString string, num int) []interface{} {
-	var ret []interface{} = make([]interface{}, num)
+	ret := make([]interface{}, num)
 	for i := 0; i < len(ret); i++ {
 		ret[i] = mock.AnythingOfTypeArgument(typeString)
 	}

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -54,15 +54,15 @@ var samplePollTwoOptions = Poll{
 
 func setupTestPlugin(t *testing.T, api *plugintest.API, siteURL string) *MatterpollPlugin {
 	p := &MatterpollPlugin{
-		Config: &Config{
-			Trigger: "poll",
-		},
 		ServerConfig: &model.Config{
 			ServiceSettings: model.ServiceSettings{
 				SiteURL: &siteURL,
 			},
 		},
 	}
+	p.setConfiguration(&configuration{
+		Trigger: "poll",
+	})
 	p.SetAPI(api)
 	err := p.OnActivate()
 	require.Nil(t, err)
@@ -71,19 +71,12 @@ func setupTestPlugin(t *testing.T, api *plugintest.API, siteURL string) *Matterp
 
 func TestPluginOnActivate(t *testing.T) {
 	t.Run("all fine", func(t *testing.T) {
-		p := &MatterpollPlugin{
-			Config: &Config{
-				Trigger: "poll",
-			},
-		}
+		p := &MatterpollPlugin{}
+		p.setConfiguration(&configuration{
+			Trigger: "poll",
+		})
 		err := p.OnActivate()
 		assert.Nil(t, err)
-	})
-
-	t.Run("empty config", func(t *testing.T) {
-		p := &MatterpollPlugin{}
-		err := p.OnActivate()
-		assert.NotNil(t, err)
 	})
 }
 
@@ -91,7 +84,7 @@ func TestPluginOnDeactivate(t *testing.T) {
 	t.Run("all fine", func(t *testing.T) {
 		api := &plugintest.API{}
 		p := setupTestPlugin(t, api, samplesiteURL)
-		api.On("UnregisterCommand", "", p.Config.Trigger).Return(nil)
+		api.On("UnregisterCommand", "", p.getConfiguration().Trigger).Return(nil)
 		defer api.AssertExpectations(t)
 
 		err := p.OnDeactivate()
@@ -101,7 +94,7 @@ func TestPluginOnDeactivate(t *testing.T) {
 	t.Run("UnregisterCommand fails", func(t *testing.T) {
 		api := &plugintest.API{}
 		p := setupTestPlugin(t, api, samplesiteURL)
-		api.On("UnregisterCommand", "", p.Config.Trigger).Return(&model.AppError{})
+		api.On("UnregisterCommand", "", p.getConfiguration().Trigger).Return(&model.AppError{})
 		defer api.AssertExpectations(t)
 
 		err := p.OnDeactivate()

--- a/server/poll.go
+++ b/server/poll.go
@@ -58,7 +58,7 @@ func (p *Poll) ToPostActions(siteURL, pollID, authorName string) []*model.SlackA
 			Name: answer,
 			Type: model.POST_ACTION_TYPE_BUTTON,
 			Integration: &model.PostActionIntegration{
-				URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/vote/%v", siteURL, PluginId, CurrentApiVersion, pollID, i),
+				URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/vote/%v", siteURL, PluginId, CurrentAPIVersion, pollID, i),
 			},
 		})
 	}
@@ -67,7 +67,7 @@ func (p *Poll) ToPostActions(siteURL, pollID, authorName string) []*model.SlackA
 		Name: "Delete Poll",
 		Type: model.POST_ACTION_TYPE_BUTTON,
 		Integration: &model.PostActionIntegration{
-			URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/delete", siteURL, PluginId, CurrentApiVersion, pollID),
+			URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/delete", siteURL, PluginId, CurrentAPIVersion, pollID),
 		},
 	})
 
@@ -75,7 +75,7 @@ func (p *Poll) ToPostActions(siteURL, pollID, authorName string) []*model.SlackA
 		Name: "End Poll",
 		Type: model.POST_ACTION_TYPE_BUTTON,
 		Integration: &model.PostActionIntegration{
-			URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/end", siteURL, PluginId, CurrentApiVersion, pollID),
+			URL: fmt.Sprintf("%s/plugins/%s/api/%s/polls/%s/end", siteURL, PluginId, CurrentAPIVersion, pollID),
 		},
 	})
 

--- a/server/utils.go
+++ b/server/utils.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 )
 
+// ParseInput pares a given input and tries to extract the poll question and poll options
 func ParseInput(input string, trigger string) (string, []string, []string) {
 	settings := []string{}
 

--- a/server/versions.go
+++ b/server/versions.go
@@ -5,9 +5,13 @@ package main
 var apiVersions = []string{
 	"v1",
 }
-var CurrentApiVersion = apiVersions[0]
+
+// CurrentAPIVersion is the newest API version
+var CurrentAPIVersion = apiVersions[0]
 
 var dataSchemaVersions = []string{
 	"v1",
 }
+
+// CurrentDataSchemaVersion is the newest data schema version
 var CurrentDataSchemaVersion = dataSchemaVersions[0]


### PR DESCRIPTION
Since plugin methods are called asynchrony `Config` could be changed any time. This PR fixes this by using a lock. It is pretty much a downstream of https://github.com/mattermost/mattermost-plugin-demo/pull/7.

The second commit fixes come linter issues. Some day I will learn to submit separate PRs for this. Sorry @kaakaa.