### PR TITLE
Enforce minimum server version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Matterpoll is a plugin for [Mattermost](https://mattermost.com/). It allows users to create poll by using a slash command.
 
-Supported Mattermost Server Versions: 5.3+
+Supported Mattermost Server Versions: 5.4+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -39,3 +39,10 @@ Poll Settings provider further customisation, e.g. `/poll "Is Matterpoll great?"
 
 Make sure to set your [Site URL](https://docs.mattermost.com/administration/config-settings.html?highlight=site%20url#site-url) properly.
 For example, this error happens in case you set SiteURL starting with `http://`, in spite of running Mattermost server through https.
+
+ <!-- TODO: Remove this when Mattermost 5.5 is released -->
+#### **Poll command returns error `Received invalid response from the server`**
+
+Check system logs. If you find the following message, Matterpoll doesn't support your Mattermost. Please update your Mattermost server.
+
+`RPC call to GetServerVersion API failed: rpc: can't find method Plugin.GetServerVersion	{"plugin_id": "com.github.matterpoll.matterpoll", "source": "plugin_stderr"}`

--- a/server/Gopkg.lock
+++ b/server/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:aba270497eb2d49f5cba6f4162d524b9a1195a24cbce8be20bf56a0051f47deb"
+  name = "github.com/blang/semver"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "2ee87856327ba09384cabd113bc6b5d174e9ec0f"
+  version = "v3.5.1"
+
+[[projects]]
   digest = "1:d83a0c69ae2f09a89d2c2a05d1158c522947d681c26cd5a0c25a39ca8ed031a9"
   name = "github.com/bouk/monkey"
   packages = ["."]
@@ -424,6 +432,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/blang/semver",
     "github.com/bouk/monkey",
     "github.com/gorilla/mux",
     "github.com/mattermost/mattermost-server/model",

--- a/server/Gopkg.toml
+++ b/server/Gopkg.toml
@@ -22,3 +22,6 @@
 [[constraint]]
   name = "github.com/pkg/errors"
   version = "~0.8.0"
+[[constraint]]
+  name = "github.com/blang/semver"
+  version = "~3.5.0"

--- a/server/api.go
+++ b/server/api.go
@@ -171,10 +171,7 @@ func (p *MatterpollPlugin) handleEndPoll(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// TODO: Remove this check, when we drop the support Mattermost v5.3
-	if request.TeamId != "" {
-		p.postEndPollAnnouncement(request, poll.Question)
-	}
+	p.postEndPollAnnouncement(request, poll.Question)
 
 	writePostActionIntegrationResponse(w, response)
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -25,7 +25,7 @@ type MatterpollPlugin struct {
 	ServerConfig  *model.Config
 }
 
-const minimumServerVersion = "5.4.0-rc1"
+const minimumServerVersion = "5.4.0"
 
 // OnActivate ensures a configuration is set and initalises the API
 func (p *MatterpollPlugin) OnActivate() error {


### PR DESCRIPTION
This PR makes use of `GetServerVersion()` and enforces a minimum Mattermost server version. It also bumps the minimum server version to 5.4. Otherwise we can't use `GetServerVersion()`.