### PR TITLE
Don't post ephemeral message if query is invalid

### DIFF
--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -23,7 +23,7 @@ const (
 		"- `--progress`: During the poll, show how many votes each answer option got\n"
 
 	// Parameter: Trigger
-	commandInputErrorFormat = "Invalid input. Try `/%[1]s \"Question\"` or `/%[1]s \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\"`"
+	commandInputErrorFormat = "Invalid input. Try /%[1]s \"Question\" or /%[1]s \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\""
 	commandGenericError     = "Something went bad. Please try again later."
 )
 
@@ -39,8 +39,11 @@ func (p *MatterpollPlugin) ExecuteCommand(c *plugin.Context, args *model.Command
 		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, msg, siteURL, nil), nil
 	}
 	if len(o) == 1 {
-		msg := fmt.Sprintf(commandInputErrorFormat, configuration.Trigger)
-		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, msg, siteURL, nil), nil
+		return nil, &model.AppError{
+			Id:         fmt.Sprintf(commandInputErrorFormat, configuration.Trigger),
+			StatusCode: http.StatusBadRequest,
+			Where:      "ExecuteCommand",
+		}
 	}
 
 	var newPoll *poll.Poll

--- a/server/plugin/command_test.go
+++ b/server/plugin/command_test.go
@@ -45,12 +45,10 @@ func TestPluginExecuteCommand(t *testing.T) {
 			ExpectedAttachments:  nil,
 		},
 		"Two arguments": {
-			SetupAPI:             func(api *plugintest.API) *plugintest.API { return api },
-			SetupStore:           func(store *mockstore.Store) *mockstore.Store { return store },
-			Command:              fmt.Sprintf("/%s \"Question\" \"Just one option\"", trigger),
-			ExpectedResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
-			ExpectedText:         fmt.Sprintf(commandInputErrorFormat, trigger),
-			ExpectedAttachments:  nil,
+			SetupAPI:    func(api *plugintest.API) *plugintest.API { return api },
+			SetupStore:  func(store *mockstore.Store) *mockstore.Store { return store },
+			Command:     fmt.Sprintf("/%s \"Question\" \"Just one option\"", trigger),
+			ShouldError: true,
 		},
 		"Just question": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
@@ -143,13 +141,10 @@ func TestPluginExecuteCommand(t *testing.T) {
 			ExpectedAttachments:  nil,
 		},
 		"Invalid setting": {
-			SetupAPI:             func(api *plugintest.API) *plugintest.API { return api },
-			SetupStore:           func(store *mockstore.Store) *mockstore.Store { return store },
-			Command:              fmt.Sprintf("/%s \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\" --unkownOption", trigger),
-			ExpectedResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
-			ExpectedText:         fmt.Sprintf("Invalid input: Unrecognised poll setting unkownOption"),
-			ExpectedAttachments:  nil,
-			ShouldError:          true,
+			SetupAPI:    func(api *plugintest.API) *plugintest.API { return api },
+			SetupStore:  func(store *mockstore.Store) *mockstore.Store { return store },
+			Command:     fmt.Sprintf("/%s \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\" --unkownOption", trigger),
+			ShouldError: true,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Typing `/poll "Something or other" yes no maybe` now shows:
![screenshot from 2018-10-31 21-06-40](https://user-images.githubusercontent.com/16541325/47815583-0887b100-dd51-11e8-9a26-2566db0a1ae1.png)

This cover two cases:
- A unknown setting is provided
- Just two arguments are given e.g. `/poll "abc" "def"`

Fixes #101 