### PR TITLE
Serve logo relative to executable path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ endif
 .PHONY: test
 test: server/.depensure webapp/.npminstall
 ifneq ($(HAS_SERVER),)
-	cd server && $(GO) test -race -v -coverprofile=coverage.txt ./...
+	cd server && $(GO) test -race -gcflags=-l -v -coverprofile=coverage.txt ./...
 endif
 ifneq ($(HAS_WEBAPP),)
 	cd webapp && $(NPM) run fix;

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ endif
 .PHONY: test
 test: server/.depensure webapp/.npminstall
 ifneq ($(HAS_SERVER),)
-	cd server && $(GO) test -race -gcflags=-l -v -coverprofile=coverage.txt ./...
+	cd server && $(GO) test -race -gcflags=-l -coverprofile=coverage.txt ./...
 endif
 ifneq ($(HAS_WEBAPP),)
 	cd webapp && $(NPM) run fix;

--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/gorilla/mux"
@@ -15,7 +17,6 @@ const (
 	infoMessage = "Thanks for using Matterpoll v" + PluginVersion + "\n"
 
 	iconFilename = "logo_dark.png"
-	iconPath     = "plugins/" + PluginId + "/"
 
 	voteCounted = "Your vote has been counted."
 	voteUpdated = "Your vote has been updated."
@@ -51,8 +52,18 @@ func (p *MatterpollPlugin) handleInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *MatterpollPlugin) handleLogo(w http.ResponseWriter, r *http.Request) {
+	// com.github.matterpoll.matterpoll/server/dist/plugin-*
+	ex, err := os.Executable()
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	// com.github.matterpoll.matterpoll/server/dist/
+	exPath := filepath.Dir(ex)
+	// com.github.matterpoll.matterpoll/logo_dark.png
+	iconPath := filepath.Dir(filepath.Dir(exPath)) + "/" + iconFilename
 	w.Header().Set("Cache-Control", "public, max-age=604800")
-	http.ServeFile(w, r, iconPath+iconFilename)
+	http.ServeFile(w, r, iconPath)
 }
 
 func (p *MatterpollPlugin) handleVote(w http.ResponseWriter, r *http.Request) {

--- a/server/plugin/api_test.go
+++ b/server/plugin/api_test.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bouk/monkey"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin/plugintest"
 	"github.com/matterpoll/matterpoll/server/store/mockstore"
@@ -99,6 +101,18 @@ func TestServeFile(t *testing.T) {
 			},
 			ExpectedStatusCode: http.StatusOK,
 			ShouldError:        false,
+		},
+		"failed to get executable": {
+			Setup: func() {
+				monkey.Patch(os.Executable, func() (string, error) {
+					return "", errors.New("failed to get executable")
+				})
+			},
+			Teardown: func() {
+				monkey.Patch(os.Executable, func() (string, error) { return "", errors.New("failed to get executable") }).Unpatch()
+			},
+			ExpectedStatusCode: http.StatusInternalServerError,
+			ShouldError:        true,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/server/plugin/api_test.go
+++ b/server/plugin/api_test.go
@@ -78,9 +78,7 @@ func TestServeFile(t *testing.T) {
 		"all fine": {
 			Setup: func() {
 				ex, err := os.Executable()
-				if err != nil {
-					panic(err)
-				}
+				require.Nil(t, err)
 				exPath := filepath.Dir(ex)
 				iconPath := filepath.Dir(filepath.Dir(exPath)) + "/" + iconFilename
 
@@ -90,11 +88,10 @@ func TestServeFile(t *testing.T) {
 			},
 			Teardown: func() {
 				ex, err := os.Executable()
-				if err != nil {
-					panic(err)
-				}
+				require.Nil(t, err)
 				exPath := filepath.Dir(ex)
 				iconPath := filepath.Dir(filepath.Dir(exPath)) + "/" + iconFilename
+
 				rmCmd := exec.Command("rm", "-r", iconPath)
 				err = rmCmd.Run()
 				require.Nil(t, err)
@@ -136,6 +133,8 @@ func TestServeFile(t *testing.T) {
 
 			assert.Equal(test.ExpectedStatusCode, result.StatusCode)
 			if test.ShouldError {
+				assert.Equal([]byte{}, bodyBytes)
+				assert.Equal(http.Header{}, result.Header)
 			} else {
 				assert.NotNil(bodyBytes)
 				assert.Contains([]string{"image/png"}, result.Header.Get("Content-Type"))


### PR DESCRIPTION
We used to server files relative to the working directory.
But this can't be considered reliable. This commit changes the way we 
look for files looking for them relative to the executable path.  Since 
he know how the directories under the executable are strutured, this is 
a save way.

This commit also changes the tests accordingly.

@kaakaa One technical note: I don't know how to test `os.Executable()`'s error case. I tried to use monkey patching but it didn't work. See f10ecdbd9a9c5245212bb8810cb05bbf656d6a88.

@JamonBarns @geberl @m49808 @zetaab Please test this PR, if you have the time. You can use 
[com.github.matterpoll.matterpoll-1.0.1.tar.gz](https://github.com/matterpoll/matterpoll/files/2553310/com.github.matterpoll.matterpoll-1.0.1.tar.gz) or compile it yourself.

Fixes #91 