### PR TITLE
Use Bot Account

### DIFF
--- a/assets/i18n/active.de.json
+++ b/assets/i18n/active.de.json
@@ -1,4 +1,8 @@
 {
+  "bot.description": {
+    "hash": "sha1-a007d7390f1601bbdc83a397f619335ed591699f",
+    "other": "Umfragen Bot"
+  },
   "command.default.no": {
     "hash": "sha1-816c52fd2bdd94a63cd0944823a6c0aa9384c103",
     "other": "Nein"

--- a/assets/i18n/active.en.json
+++ b/assets/i18n/active.en.json
@@ -1,4 +1,5 @@
 {
+  "bot.description": "Poll Bot",
   "command.default.no": "No",
   "command.default.yes": "Yes",
   "command.error.generic": "Something went wrong. Please try again later.",

--- a/server/Gopkg.lock
+++ b/server/Gopkg.lock
@@ -118,7 +118,15 @@
   revision = "2f1d1f20f75d5404f53b9edf6b53ed5505508675"
 
 [[projects]]
-  digest = "1:77c91150dbdad987cb9a3cce01cee3ebcfb05ab346f2e450009f4d2d6a53bf36"
+  digest = "1:60ac67c5e4ea431ce6936f7d89a686013060e9963a8ed58dbc791b576ce8053c"
+  name = "github.com/mattermost/go-i18n"
+  packages = ["i18n"]
+  pruneopts = "NUT"
+  revision = "0dc1626d56435e9d605a29875701721c54bc9bbd"
+  version = "v1.10.0"
+
+[[projects]]
+  digest = "1:3facc5fe9f585d4d210152fb6d4cfbbf6f29b26dc5a9c248f79cd6bc3e9b3478"
   name = "github.com/mattermost/mattermost-server"
   packages = [
     "mlog",
@@ -132,8 +140,7 @@
     "utils/markdown",
   ]
   pruneopts = "NUT"
-  revision = "dc70ab42034da17eaf23be5a86abae81b3f1cd21"
-  version = "v5.10.0"
+  revision = "66cb36f5dc35e75f51e08734374b8009d96a8392"
 
 [[projects]]
   digest = "1:18b773b92ac82a451c1276bd2776c1e55ce057ee202691ab33c8d6690efcc048"
@@ -144,10 +151,9 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:e8361c2cf0d07059672f0831ec7926b9bf84c393e1e2dcdaec01c95be9564b42"
+  digest = "1:514d92aacbc91cdca325c83550c9ed0f6d08c6c3815d3c8e6ee1b0b8fce6dc90"
   name = "github.com/nicksnyder/go-i18n"
   packages = [
-    "i18n",
     "i18n/bundle",
     "i18n/language",
     "i18n/translation",

--- a/server/Gopkg.toml
+++ b/server/Gopkg.toml
@@ -5,7 +5,7 @@
 
 [[constraint]]
   name = "github.com/mattermost/mattermost-server"
-  version = "~5.10.0"
+  revision = "66cb36f5dc35e75f51e08734374b8009d96a8392"
 
 [[constraint]]
   name = "github.com/stretchr/testify"

--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -374,7 +374,7 @@ func (p *MatterpollPlugin) postEndPollAnnouncement(request *model.PostActionInte
 	publicLocalizer := p.getServerLocalizer()
 
 	endPost := &model.Post{
-		UserId:    request.UserId,
+		UserId:    p.botUserID,
 		ChannelId: channelID,
 		RootId:    request.PostId,
 		Message: p.LocalizeWithConfig(publicLocalizer, &i18n.LocalizeConfig{
@@ -384,11 +384,6 @@ func (p *MatterpollPlugin) postEndPollAnnouncement(request *model.PostActionInte
 				"Link":     link,
 			}}),
 		Type: model.POST_DEFAULT,
-		Props: model.StringInterface{
-			"override_username": responseUsername,
-			"override_icon_url": fmt.Sprintf(responseIconURL, *p.ServerConfig.ServiceSettings.SiteURL, PluginId),
-			"from_webhook":      "true",
-		},
 	}
 
 	if _, err = p.API.CreatePost(endPost); err != nil {

--- a/server/plugin/api_test.go
+++ b/server/plugin/api_test.go
@@ -292,13 +292,8 @@ func TestHandleAddOption(t *testing.T) {
 
 	responsePost := &model.Post{
 		ChannelId: channelID,
-		UserId:    userID,
+		UserId:    testutils.GetBotUserID(),
 		Message:   responseAddOptionSuccess.Other,
-		Props: map[string]interface{}{
-			"from_webhook":      "true",
-			"override_icon_url": fmt.Sprintf(responseIconURL, testutils.GetSiteURL(), PluginId),
-			"override_username": responseUsername,
-		},
 	}
 
 	poll1In := testutils.GetPollWithVotes()
@@ -671,7 +666,7 @@ func TestPostEndPollAnnouncement(t *testing.T) {
 				api.On("GetTeam", "teamID1").Return(&model.Team{Name: "team1"}, nil)
 				api.On("GetPost", "postID1").Return(&model.Post{ChannelId: "channelID1"}, nil)
 				api.On("CreatePost", &model.Post{
-					UserId:    "userID1",
+					UserId:    testutils.GetBotUserID(),
 					ChannelId: "channelID1",
 					RootId:    "postID1",
 					Message: testutils.GetLocalizer().MustLocalize(
@@ -683,11 +678,6 @@ func TestPostEndPollAnnouncement(t *testing.T) {
 							}}),
 
 					Type: model.POST_DEFAULT,
-					Props: model.StringInterface{
-						"override_username": responseUsername,
-						"override_icon_url": fmt.Sprintf(responseIconURL, "https://example.org", PluginId),
-						"from_webhook":      "true",
-					},
 				}).Return(nil, nil)
 				return api
 			},

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/mattermost/mattermost-server/model"
@@ -68,8 +67,15 @@ var (
 
 // ExecuteCommand parses a given input and creates a poll if the input is correct
 func (p *MatterpollPlugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+	msg, appErr := p.executeCommand(args)
+	if msg != "" {
+		p.SendEphemeralPost(args.ChannelId, args.UserId, msg)
+	}
+	return &model.CommandResponse{}, appErr
+}
+
+func (p *MatterpollPlugin) executeCommand(args *model.CommandArgs) (string, *model.AppError) {
 	creatorID := args.UserId
-	siteURL := *p.ServerConfig.ServiceSettings.SiteURL
 	configuration := p.getConfiguration()
 
 	userLocalizer := p.getUserLocalizer(creatorID)
@@ -96,10 +102,10 @@ func (p *MatterpollPlugin) ExecuteCommand(c *plugin.Context, args *model.Command
 		msg += "- `--progress`: " + p.LocalizeDefaultMessage(userLocalizer, commandHelpTextPollSettingProgress) + "\n"
 		msg += "- `--public-add-option`: " + p.LocalizeDefaultMessage(userLocalizer, commandHelpTextPollSettingPublicAddOption)
 
-		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, msg, siteURL, nil), nil
+		return msg, nil
 	}
 	if len(o) == 1 {
-		return nil, &model.AppError{
+		return "", &model.AppError{
 			Id:         p.LocalizeDefaultMessage(userLocalizer, commandErrorinvalidNumberOfOptions),
 			StatusCode: http.StatusBadRequest,
 			Where:      "ExecuteCommand",
@@ -114,7 +120,7 @@ func (p *MatterpollPlugin) ExecuteCommand(c *plugin.Context, args *model.Command
 		newPoll, err = poll.NewPoll(creatorID, q, o, s)
 	}
 	if err != nil {
-		return nil, &model.AppError{
+		appErr := &model.AppError{
 			Id: p.LocalizeWithConfig(userLocalizer, &i18n.LocalizeConfig{
 				DefaultMessage: commandErrorInvalidInput,
 				TemplateData: map[string]interface{}{
@@ -123,34 +129,36 @@ func (p *MatterpollPlugin) ExecuteCommand(c *plugin.Context, args *model.Command
 			StatusCode: http.StatusBadRequest,
 			Where:      "ExecuteCommand",
 		}
+		return "", appErr
 	}
 
 	if err := p.Store.Poll().Save(newPoll); err != nil {
 		p.API.LogError("failed to save poll", "err", err.Error())
-		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, p.LocalizeDefaultMessage(userLocalizer, commandErrorGeneric), siteURL, nil), nil
+		return p.LocalizeDefaultMessage(userLocalizer, commandErrorGeneric), nil
 	}
 
 	displayName, appErr := p.ConvertCreatorIDToDisplayName(creatorID)
 	if appErr != nil {
 		p.API.LogError("failed to ConvertCreatorIDToDisplayName", "err", appErr.Error())
-		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, p.LocalizeDefaultMessage(userLocalizer, commandErrorGeneric), siteURL, nil), nil
+		return p.LocalizeDefaultMessage(userLocalizer, commandErrorGeneric), nil
 	}
 
 	actions := newPoll.ToPostActions(publicLocalizer, *p.ServerConfig.ServiceSettings.SiteURL, PluginId, displayName)
-	response := getCommandResponse(model.COMMAND_RESPONSE_TYPE_IN_CHANNEL, "", *p.ServerConfig.ServiceSettings.SiteURL, actions)
-	p.API.LogDebug("Created a new poll", "response", response.ToJson())
-	return response, nil
-}
-
-func getCommandResponse(responseType, text, siteURL string, attachments []*model.SlackAttachment) *model.CommandResponse {
-	return &model.CommandResponse{
-		ResponseType: responseType,
-		Text:         text,
-		Username:     responseUsername,
-		IconURL:      fmt.Sprintf(responseIconURL, siteURL, PluginId),
-		Type:         model.POST_DEFAULT,
-		Attachments:  attachments,
+	post := &model.Post{
+		UserId:    p.botUserID,
+		ChannelId: args.ChannelId,
+		RootId:    args.RootId,
+		Type:      model.POST_DEFAULT,
 	}
+	model.ParseSlackAttachment(post, actions)
+
+	if _, appErr = p.API.CreatePost(post); appErr != nil {
+		p.API.LogError("failed to post poll post", "error", appErr.Error())
+		return p.LocalizeDefaultMessage(userLocalizer, commandErrorGeneric), nil
+	}
+
+	p.API.LogDebug("Created a new poll", "post", post.ToJson())
+	return "", nil
 }
 
 func getCommand(trigger string) *model.Command {

--- a/server/plugin/command_test.go
+++ b/server/plugin/command_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/matterpoll/matterpoll/server/store/mockstore"
 	"github.com/matterpoll/matterpoll/server/utils/testutils"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestPluginExecuteCommand(t *testing.T) {
@@ -25,29 +24,23 @@ func TestPluginExecuteCommand(t *testing.T) {
 		"- `--public-add-option`: Allow all users to add additional options"
 
 	for name, test := range map[string]struct {
-		SetupAPI             func(*plugintest.API) *plugintest.API
-		SetupStore           func(*mockstore.Store) *mockstore.Store
-		Command              string
-		ExpectedResponseType string
-		ExpectedText         string
-		ExpectedAttachments  []*model.SlackAttachment
-		ShouldError          bool
+		SetupAPI     func(*plugintest.API) *plugintest.API
+		SetupStore   func(*mockstore.Store) *mockstore.Store
+		Command      string
+		ExpectedText string
+		ShouldError  bool
 	}{
 		"No argument": {
-			SetupAPI:             func(api *plugintest.API) *plugintest.API { return api },
-			SetupStore:           func(store *mockstore.Store) *mockstore.Store { return store },
-			Command:              fmt.Sprintf("/%s", trigger),
-			ExpectedResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
-			ExpectedText:         helpText,
-			ExpectedAttachments:  nil,
+			SetupAPI:     func(api *plugintest.API) *plugintest.API { return api },
+			SetupStore:   func(store *mockstore.Store) *mockstore.Store { return store },
+			Command:      fmt.Sprintf("/%s", trigger),
+			ExpectedText: helpText,
 		},
 		"Help text": {
-			SetupAPI:             func(api *plugintest.API) *plugintest.API { return api },
-			SetupStore:           func(store *mockstore.Store) *mockstore.Store { return store },
-			Command:              fmt.Sprintf("/%s help", trigger),
-			ExpectedResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
-			ExpectedText:         helpText,
-			ExpectedAttachments:  nil,
+			SetupAPI:     func(api *plugintest.API) *plugintest.API { return api },
+			SetupStore:   func(store *mockstore.Store) *mockstore.Store { return store },
+			Command:      fmt.Sprintf("/%s help", trigger),
+			ExpectedText: helpText,
 		},
 		"Two arguments": {
 			SetupAPI:    func(api *plugintest.API) *plugintest.API { return api },
@@ -59,36 +52,83 @@ func TestPluginExecuteCommand(t *testing.T) {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
 				api.On("GetUser", "userID1").Return(&model.User{FirstName: "John", LastName: "Doe"}, nil)
 				api.On("LogDebug", GetMockArgumentsWithType("string", 3)...).Return()
+
+				post := &model.Post{
+					UserId:    testutils.GetBotUserID(),
+					ChannelId: "channelID1",
+					RootId:    "postID1",
+					Type:      model.POST_DEFAULT,
+				}
+				actions := testutils.GetPollTwoOptions().ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), PluginId, "John Doe")
+				model.ParseSlackAttachment(post, actions)
+				api.On("CreatePost", post).Return(post, nil)
 				return api
 			},
 			SetupStore: func(store *mockstore.Store) *mockstore.Store {
 				store.PollStore.On("Save", testutils.GetPollTwoOptions()).Return(nil)
 				return store
 			},
-			Command:              fmt.Sprintf("/%s \"Question\"", trigger),
-			ExpectedResponseType: model.COMMAND_RESPONSE_TYPE_IN_CHANNEL,
-			ExpectedText:         "",
-			ExpectedAttachments:  testutils.GetPollTwoOptions().ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), PluginId, "John Doe"),
+			Command: fmt.Sprintf("/%s \"Question\"", trigger),
+		},
+		"Just question, CreatePost fails": {
+			SetupAPI: func(api *plugintest.API) *plugintest.API {
+				api.On("GetUser", "userID1").Return(&model.User{FirstName: "John", LastName: "Doe"}, nil)
+
+				post := &model.Post{
+					UserId:    testutils.GetBotUserID(),
+					ChannelId: "channelID1",
+					RootId:    "postID1",
+					Type:      model.POST_DEFAULT,
+				}
+				actions := testutils.GetPollTwoOptions().ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), PluginId, "John Doe")
+				model.ParseSlackAttachment(post, actions)
+				api.On("CreatePost", post).Return(nil, &model.AppError{})
+				api.On("LogError", GetMockArgumentsWithType("string", 3)...).Return()
+				return api
+			},
+			SetupStore: func(store *mockstore.Store) *mockstore.Store {
+				store.PollStore.On("Save", testutils.GetPollTwoOptions()).Return(nil)
+				return store
+			},
+			Command:      fmt.Sprintf("/%s \"Question\"", trigger),
+			ExpectedText: commandErrorGeneric.Other,
 		},
 		"With 4 arguments": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
 				api.On("GetUser", "userID1").Return(&model.User{FirstName: "John", LastName: "Doe"}, nil)
 				api.On("LogDebug", GetMockArgumentsWithType("string", 3)...).Return()
+
+				post := &model.Post{
+					UserId:    testutils.GetBotUserID(),
+					ChannelId: "channelID1",
+					RootId:    "postID1",
+					Type:      model.POST_DEFAULT,
+				}
+				actions := testutils.GetPoll().ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), PluginId, "John Doe")
+				model.ParseSlackAttachment(post, actions)
+				api.On("CreatePost", post).Return(post, nil)
 				return api
 			},
 			SetupStore: func(store *mockstore.Store) *mockstore.Store {
 				store.PollStore.On("Save", testutils.GetPoll()).Return(nil)
 				return store
 			},
-			Command:              fmt.Sprintf("/%s \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\"", trigger),
-			ExpectedResponseType: model.COMMAND_RESPONSE_TYPE_IN_CHANNEL,
-			ExpectedText:         "",
-			ExpectedAttachments:  testutils.GetPoll().ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), PluginId, "John Doe"),
+			Command: fmt.Sprintf("/%s \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\"", trigger),
 		},
 		"With 4 arguments and settting progress": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
 				api.On("GetUser", "userID1").Return(&model.User{FirstName: "John", LastName: "Doe"}, nil)
 				api.On("LogDebug", GetMockArgumentsWithType("string", 3)...).Return()
+
+				post := &model.Post{
+					UserId:    testutils.GetBotUserID(),
+					ChannelId: "channelID1",
+					RootId:    "postID1",
+					Type:      model.POST_DEFAULT,
+				}
+				actions := testutils.GetPollWithSettings(poll.PollSettings{Progress: true}).ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), PluginId, "John Doe")
+				model.ParseSlackAttachment(post, actions)
+				api.On("CreatePost", post).Return(post, nil)
 				return api
 			},
 			SetupStore: func(store *mockstore.Store) *mockstore.Store {
@@ -96,14 +136,22 @@ func TestPluginExecuteCommand(t *testing.T) {
 				store.PollStore.On("Save", poll).Return(nil)
 				return store
 			},
-			Command:              fmt.Sprintf("/%s \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\" --progress", trigger),
-			ExpectedResponseType: model.COMMAND_RESPONSE_TYPE_IN_CHANNEL,
-			ExpectedAttachments:  testutils.GetPollWithSettings(poll.PollSettings{Progress: true}).ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), PluginId, "John Doe"),
+			Command: fmt.Sprintf("/%s \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\" --progress", trigger),
 		},
 		"With 4 arguments and settting anonymous and progress": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
 				api.On("GetUser", "userID1").Return(&model.User{FirstName: "John", LastName: "Doe"}, nil)
 				api.On("LogDebug", GetMockArgumentsWithType("string", 3)...).Return()
+
+				post := &model.Post{
+					UserId:    testutils.GetBotUserID(),
+					ChannelId: "channelID1",
+					RootId:    "postID1",
+					Type:      model.POST_DEFAULT,
+				}
+				actions := testutils.GetPollWithSettings(poll.PollSettings{Progress: true, Anonymous: true}).ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), PluginId, "John Doe")
+				model.ParseSlackAttachment(post, actions)
+				api.On("CreatePost", post).Return(post, nil)
 				return api
 			},
 			SetupStore: func(store *mockstore.Store) *mockstore.Store {
@@ -111,10 +159,7 @@ func TestPluginExecuteCommand(t *testing.T) {
 				store.PollStore.On("Save", poll).Return(nil)
 				return store
 			},
-			Command:              fmt.Sprintf("/%s \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\" --anonymous --progress", trigger),
-			ExpectedResponseType: model.COMMAND_RESPONSE_TYPE_IN_CHANNEL,
-			ExpectedText:         "",
-			ExpectedAttachments:  testutils.GetPollWithSettings(poll.PollSettings{Progress: true, Anonymous: true}).ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), PluginId, "John Doe"),
+			Command: fmt.Sprintf("/%s \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\" --anonymous --progress", trigger),
 		},
 		"Store.Save fails": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
@@ -125,10 +170,8 @@ func TestPluginExecuteCommand(t *testing.T) {
 				store.PollStore.On("Save", testutils.GetPoll()).Return(errors.New(""))
 				return store
 			},
-			Command:              fmt.Sprintf("/%s \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\"", trigger),
-			ExpectedResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
-			ExpectedText:         commandErrorGeneric.Other,
-			ExpectedAttachments:  nil,
+			Command:      fmt.Sprintf("/%s \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\"", trigger),
+			ExpectedText: commandErrorGeneric.Other,
 		},
 		"GetUser fails": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
@@ -141,10 +184,8 @@ func TestPluginExecuteCommand(t *testing.T) {
 				store.PollStore.On("Save", testutils.GetPoll()).Return(nil)
 				return store
 			},
-			Command:              fmt.Sprintf("/%s \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\"", trigger),
-			ExpectedResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
-			ExpectedText:         commandErrorGeneric.Other,
-			ExpectedAttachments:  nil,
+			Command:      fmt.Sprintf("/%s \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\"", trigger),
+			ExpectedText: commandErrorGeneric.Other,
 		},
 		"Invalid setting": {
 			SetupAPI:    func(api *plugintest.API) *plugintest.API { return api },
@@ -158,6 +199,14 @@ func TestPluginExecuteCommand(t *testing.T) {
 
 			api := test.SetupAPI(&plugintest.API{})
 			api.On("GetUser", "userID1").Return(&model.User{Username: "user1"}, nil)
+			if test.ExpectedText != "" {
+				ephemeralPost := &model.Post{
+					ChannelId: "channelID1",
+					UserId:    testutils.GetBotUserID(),
+					Message:   test.ExpectedText,
+				}
+				api.On("SendEphemeralPost", "userID1", ephemeralPost).Return(nil)
+			}
 			defer api.AssertExpectations(t)
 			store := test.SetupStore(&mockstore.Store{})
 			defer store.AssertExpectations(t)
@@ -170,22 +219,17 @@ func TestPluginExecuteCommand(t *testing.T) {
 			defer patch2.Unpatch()
 
 			r, err := p.ExecuteCommand(nil, &model.CommandArgs{
-				Command: test.Command,
-				UserId:  "userID1",
+				Command:   test.Command,
+				UserId:    "userID1",
+				ChannelId: "channelID1",
+				RootId:    "postID1",
 			})
 
+			assert.Equal(&model.CommandResponse{}, r)
 			if test.ShouldError {
-				assert.Nil(r)
 				assert.NotNil(err)
 			} else {
 				assert.Nil(err)
-				require.NotNil(t, r)
-				assert.Equal(model.POST_DEFAULT, r.Type)
-				assert.Equal(responseUsername, r.Username)
-				assert.Equal(fmt.Sprintf(responseIconURL, testutils.GetSiteURL(), PluginId), r.IconURL)
-				assert.Equal(test.ExpectedResponseType, r.ResponseType)
-				assert.Equal(test.ExpectedText, r.Text)
-				assert.Equal(test.ExpectedAttachments, r.Attachments)
 			}
 		})
 	}

--- a/server/plugin/configuration.go
+++ b/server/plugin/configuration.go
@@ -15,6 +15,7 @@ type configuration struct {
 func (p *MatterpollPlugin) OnConfigurationChange() error {
 	configuration := new(configuration)
 	oldConfiguration := p.getConfiguration()
+	p.ServerConfig = p.API.GetConfig()
 
 	if err := p.API.LoadPluginConfiguration(configuration); err != nil {
 		return errors.Wrap(err, "failed to load plugin configuration")
@@ -32,9 +33,16 @@ func (p *MatterpollPlugin) OnConfigurationChange() error {
 	if err := p.API.RegisterCommand(getCommand(configuration.Trigger)); err != nil {
 		return errors.Wrap(err, "failed to register new command")
 	}
-	p.setConfiguration(configuration)
 
-	p.ServerConfig = p.API.GetConfig()
+	// This require a loaded i18n bundle
+	if p.isActivated() {
+		// Update bot description
+		if err := p.patchBotDescription(); err != nil {
+			return errors.Wrap(err, "failed to patch bot description")
+		}
+	}
+
+	p.setConfiguration(configuration)
 
 	return nil
 }

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -2,6 +2,8 @@ package plugin
 
 import (
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
 	"sync"
 
 	"github.com/blang/semver"
@@ -18,8 +20,13 @@ import (
 // MatterpollPlugin is the object to run the plugin
 type MatterpollPlugin struct {
 	plugin.MattermostPlugin
-	router *mux.Router
-	Store  store.Store
+	botUserID string
+	bundle    *i18n.Bundle
+	router    *mux.Router
+	Store     store.Store
+
+	// activated is used to track whether or not OnActivate has initialized the plugin state.
+	activated bool
 
 	// configurationLock synchronizes access to the configuration.
 	configurationLock sync.RWMutex
@@ -28,15 +35,24 @@ type MatterpollPlugin struct {
 	// setConfiguration for usage.
 	configuration *configuration
 	ServerConfig  *model.Config
-
-	bundle *i18n.Bundle
 }
 
-const minimumServerVersion = "5.10.0"
+var botDescription = &i18n.Message{
+	ID:    "bot.description",
+	Other: "Poll Bot",
+}
+
+const (
+	minimumServerVersion = "5.10.0"
+
+	botUserName    = "matterpoll"
+	botDisplayName = "Matterpoll"
+)
 
 // OnActivate ensures a configuration is set and initializes the API
 func (p *MatterpollPlugin) OnActivate() error {
-	if err := p.checkServerVersion(); err != nil {
+	var err error
+	if err = p.checkServerVersion(); err != nil {
 		return err
 	}
 
@@ -44,19 +60,37 @@ func (p *MatterpollPlugin) OnActivate() error {
 		return errors.New("siteURL is not set. Please set a siteURL and restart the plugin")
 	}
 
-	store, err := kvstore.NewStore(p.API, PluginVersion)
+	p.Store, err = kvstore.NewStore(p.API, PluginVersion)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to create store")
 	}
-	p.Store = store
 
-	p.router = p.InitAPI()
-
-	bundle, err := p.initBundle()
+	p.bundle, err = p.initBundle()
 	if err != nil {
 		return errors.Wrap(err, "failed to init localisation bundle")
 	}
-	p.bundle = bundle
+
+	bot := &model.Bot{
+		Username:    botUserName,
+		DisplayName: botDisplayName,
+	}
+	botUserID, appErr := p.Helpers.EnsureBot(bot)
+	if appErr != nil {
+		return errors.Wrap(appErr, "failed to ensure bot user")
+	}
+	p.botUserID = botUserID
+
+	if err = p.patchBotDescription(); err != nil {
+		return errors.Wrap(err, "failed to patch bot description")
+	}
+
+	if err = p.setProfileImage(); err != nil {
+		return errors.Wrap(err, "failed to set profile image")
+	}
+
+	p.router = p.InitAPI()
+
+	p.setActivated(true)
 
 	return nil
 }
@@ -68,6 +102,14 @@ func (p *MatterpollPlugin) OnDeactivate() error {
 		return errors.Wrap(err, "failed to dectivate command")
 	}
 	return nil
+}
+
+func (p *MatterpollPlugin) setActivated(activated bool) {
+	p.activated = activated
+}
+
+func (p *MatterpollPlugin) isActivated() bool {
+	return p.activated
 }
 
 // checkServerVersion checks Mattermost Server has at least the required version
@@ -82,6 +124,39 @@ func (p *MatterpollPlugin) checkServerVersion() error {
 		return fmt.Errorf("this plugin requires Mattermost v%s or later", minimumServerVersion)
 	}
 
+	return nil
+}
+
+// patchBotDescription updates the bot description based on the servers local
+func (p *MatterpollPlugin) patchBotDescription() error {
+	publicLocalizer := p.getServerLocalizer()
+	description := p.LocalizeDefaultMessage(publicLocalizer, botDescription)
+
+	// Update description with server local
+	botPatch := &model.BotPatch{
+		Description: &description,
+	}
+	if _, appErr := p.API.PatchBot(p.botUserID, botPatch); appErr != nil {
+		return errors.Wrap(appErr, "failed to patch bot")
+	}
+
+	return nil
+}
+
+// setProfileImage set the profile image of the bot account
+func (p *MatterpollPlugin) setProfileImage() error {
+	bundlePath, err := p.API.GetBundlePath()
+	if err != nil {
+		return errors.Wrap(err, "failed to get bundle path")
+	}
+
+	profileImage, err := ioutil.ReadFile(filepath.Join(bundlePath, "assets", "logo_dark.png"))
+	if err != nil {
+		return errors.Wrap(err, "failed to read profile image")
+	}
+	if appErr := p.API.SetProfileImage(p.botUserID, profileImage); appErr != nil {
+		return errors.Wrap(appErr, "failed to set profile image")
+	}
 	return nil
 }
 
@@ -122,14 +197,12 @@ func (p *MatterpollPlugin) HasPermission(poll *poll.Poll, issuerID string) (bool
 	return false, nil
 }
 
+// SendEphemeralPost sends an ephemeral post to a user as the bot account
 func (p *MatterpollPlugin) SendEphemeralPost(channelID, userID, message string) {
-	// This is mostly taken from https://github.com/mattermost/mattermost-server/blob/master/app/command.go#L304
-	ephemeralPost := &model.Post{}
-	ephemeralPost.ChannelId = channelID
-	ephemeralPost.UserId = userID
-	ephemeralPost.Message = message
-	ephemeralPost.AddProp("override_username", responseUsername)
-	ephemeralPost.AddProp("override_icon_url", fmt.Sprintf(responseIconURL, *p.ServerConfig.ServiceSettings.SiteURL, PluginId))
-	ephemeralPost.AddProp("from_webhook", "true")
+	ephemeralPost := &model.Post{
+		ChannelId: channelID,
+		UserId:    p.botUserID,
+		Message:   message,
+	}
 	_ = p.API.SendEphemeralPost(userID, ephemeralPost)
 }

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -101,6 +101,9 @@ func (p *MatterpollPlugin) OnDeactivate() error {
 	if err != nil {
 		return errors.Wrap(err, "failed to dectivate command")
 	}
+
+	p.setActivated(false)
+
 	return nil
 }
 

--- a/server/plugin/plugin_test.go
+++ b/server/plugin/plugin_test.go
@@ -37,17 +37,24 @@ func setupTestPlugin(t *testing.T, api *plugintest.API, store *mockstore.Store, 
 	})
 
 	p.SetAPI(api)
-	p.Store = store
-	p.router = p.InitAPI()
 	p.bundle = &i18n.Bundle{}
+	p.botUserID = testutils.GetBotUserID()
+	p.router = p.InitAPI()
+	p.Store = store
+	p.activated = true
 
 	return p
 }
 
 func TestPluginOnActivate(t *testing.T) {
+	bot := &model.Bot{
+		Username:    botUserName,
+		DisplayName: botDisplayName,
+	}
 	for name, test := range map[string]struct {
-		SetupAPI    func(*plugintest.API) *plugintest.API
-		ShouldError bool
+		SetupAPI     func(*plugintest.API) *plugintest.API
+		SetupHelpers func(*plugintest.Helpers) *plugintest.Helpers
+		ShouldError  bool
 	}{
 		// server version tests
 		"greater minor version than minimumServerVersion": {
@@ -60,7 +67,13 @@ func TestPluginOnActivate(t *testing.T) {
 				path, err := filepath.Abs("../..")
 				require.Nil(t, err)
 				api.On("GetBundlePath").Return(path, nil)
+				api.On("PatchBot", testutils.GetBotUserID(), &model.BotPatch{Description: &botDescription.Other}).Return(nil, nil)
+				api.On("SetProfileImage", testutils.GetBotUserID(), mock.Anything).Return(nil)
 				return api
+			},
+			SetupHelpers: func(helpers *plugintest.Helpers) *plugintest.Helpers {
+				helpers.On("EnsureBot", bot).Return(testutils.GetBotUserID(), nil)
+				return helpers
 			},
 			ShouldError: false,
 		},
@@ -71,7 +84,13 @@ func TestPluginOnActivate(t *testing.T) {
 				path, err := filepath.Abs("../..")
 				require.Nil(t, err)
 				api.On("GetBundlePath").Return(path, nil)
+				api.On("PatchBot", testutils.GetBotUserID(), &model.BotPatch{Description: &botDescription.Other}).Return(nil, nil)
+				api.On("SetProfileImage", testutils.GetBotUserID(), mock.Anything).Return(nil)
 				return api
+			},
+			SetupHelpers: func(helpers *plugintest.Helpers) *plugintest.Helpers {
+				helpers.On("EnsureBot", bot).Return(testutils.GetBotUserID(), nil)
+				return helpers
 			},
 			ShouldError: false,
 		},
@@ -115,20 +134,65 @@ func TestPluginOnActivate(t *testing.T) {
 			},
 			ShouldError: true,
 		},
-		/*
-			"GetBundlePath fails": {
-				SetupAPI: func(api *plugintest.API) *plugintest.API {
-					api.On("GetServerVersion").Return(minimumServerVersion)
-					api.On("GetBundlePath").Return("", errors.New(""))
-					return api
-				},
-				ShouldError: true,
+		// Bot tests
+		"EnsureBot fails ": {
+			SetupAPI: func(api *plugintest.API) *plugintest.API {
+				api.On("GetServerVersion").Return(minimumServerVersion)
+
+				path, err := filepath.Abs("../..")
+				require.Nil(t, err)
+				api.On("GetBundlePath").Return(path, nil)
+				return api
 			},
-		*/
+			SetupHelpers: func(helpers *plugintest.Helpers) *plugintest.Helpers {
+				helpers.On("EnsureBot", bot).Return("", &model.AppError{})
+				return helpers
+			},
+			ShouldError: true,
+		},
+		"patch bot description fails": {
+			SetupAPI: func(api *plugintest.API) *plugintest.API {
+				api.On("GetServerVersion").Return(minimumServerVersion)
+
+				path, err := filepath.Abs("../..")
+				require.Nil(t, err)
+				api.On("GetBundlePath").Return(path, nil)
+				api.On("PatchBot", testutils.GetBotUserID(), &model.BotPatch{Description: &botDescription.Other}).Return(nil, &model.AppError{})
+				return api
+			},
+			SetupHelpers: func(helpers *plugintest.Helpers) *plugintest.Helpers {
+				helpers.On("EnsureBot", bot).Return(testutils.GetBotUserID(), nil)
+				return helpers
+			},
+			ShouldError: true,
+		},
+		"SetProfileImage fails": {
+			SetupAPI: func(api *plugintest.API) *plugintest.API {
+				api.On("GetServerVersion").Return(minimumServerVersion)
+
+				path, err := filepath.Abs("../..")
+				require.Nil(t, err)
+				api.On("GetBundlePath").Return(path, nil)
+				api.On("PatchBot", testutils.GetBotUserID(), &model.BotPatch{Description: &botDescription.Other}).Return(nil, nil)
+				api.On("SetProfileImage", testutils.GetBotUserID(), mock.Anything).Return(&model.AppError{})
+				return api
+			},
+			SetupHelpers: func(helpers *plugintest.Helpers) *plugintest.Helpers {
+				helpers.On("EnsureBot", bot).Return(testutils.GetBotUserID(), nil)
+				return helpers
+			},
+			ShouldError: true,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			api := test.SetupAPI(&plugintest.API{})
 			defer api.AssertExpectations(t)
+
+			helpers := &plugintest.Helpers{}
+			if test.SetupHelpers != nil {
+				helpers = test.SetupHelpers(helpers)
+				defer helpers.AssertExpectations(t)
+			}
 
 			patch := monkey.Patch(kvstore.NewStore, func(plugin.API, string) (store.Store, error) {
 				return &mockstore.Store{}, nil
@@ -136,8 +200,12 @@ func TestPluginOnActivate(t *testing.T) {
 			defer patch.Unpatch()
 
 			siteURL := testutils.GetSiteURL()
+			defaultServerLocale := "en"
 			p := &MatterpollPlugin{
 				ServerConfig: &model.Config{
+					LocalizationSettings: model.LocalizationSettings{
+						DefaultServerLocale: &defaultServerLocale,
+					},
 					ServiceSettings: model.ServiceSettings{
 						SiteURL: &siteURL,
 					},
@@ -147,6 +215,7 @@ func TestPluginOnActivate(t *testing.T) {
 				Trigger: "poll",
 			})
 			p.SetAPI(api)
+			p.SetHelpers(helpers)
 			err := p.OnActivate()
 
 			if test.ShouldError {

--- a/server/store/kvstore/store.go
+++ b/server/store/kvstore/store.go
@@ -15,13 +15,9 @@ type Store struct {
 // NewStore returns a fresh store and upgrades the db from the given schema version.
 func NewStore(api plugin.API, pluginVersion string) (store.Store, error) {
 	store := Store{
-		api: api,
-		pollStore: PollStore{
-			api: api,
-		},
-		systemStore: SystemStore{
-			api: api,
-		},
+		api:         api,
+		pollStore:   PollStore{api: api},
+		systemStore: SystemStore{api: api},
 	}
 	err := store.UpdateDatabase(pluginVersion)
 	if err != nil {

--- a/server/utils/testutils/data.go
+++ b/server/utils/testutils/data.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"github.com/mattermost/mattermost-server/model"
 	"github.com/matterpoll/matterpoll/server/poll"
 )
 
@@ -12,6 +13,25 @@ func GetPollID() string {
 // GetSiteURL returns a static Site URL.
 func GetSiteURL() string {
 	return "https://example.org"
+}
+
+// GetBotUserID returns a static bot user ID.
+func GetBotUserID() string {
+	return "aegooso5na9desa0QuieV1ohfa"
+}
+
+// GetServerConfig return a static server config.
+func GetServerConfig() *model.Config {
+	siteURL := GetSiteURL()
+	defaultServerLocale := "en"
+	return &model.Config{
+		ServiceSettings: model.ServiceSettings{
+			SiteURL: &siteURL,
+		},
+		LocalizationSettings: model.LocalizationSettings{
+			DefaultServerLocale: &defaultServerLocale,
+		},
+	}
 }
 
 // GetPoll returns a Poll with three Options, no votes and no Poll Settings.


### PR DESCRIPTION
This PR makes use of the Bot Account feature coming in Mattermost v5.10.

Basically ever persistent post is now posted by the bot account. ~~Ephemeral messages are not, but this is because posting a ephemeral message as a bot account isn't supported at the moment.~~ This will be fixed with MM v5.12.

~~Please not that there are some bug in the server part. See https://community-daily.mattermost.com/core/pl/9oyf339pajfx3msy1t14fr9poh. Blocked until the webapp part of the feature is fully implemented.~~ All bugs are fixed!

The only "not bot" messages are the ones created in `api.go`. I will change this is a different PR.

Fixes #126