### PR TITLE
Fix NPE in addOption

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -170,7 +170,6 @@ func (p *MatterpollPlugin) handleAddOption(w http.ResponseWriter, r *http.Reques
 	request := model.SubmitDialogRequestFromJson(r.Body)
 	if request == nil {
 		p.API.LogError("failed to decode request")
-		p.SendEphemeralPost(request.ChannelId, request.UserId, commandErrorGeneric.Other)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
If `request == nil` we can't use the information to send a ephemeral post. Since we don't have any information, there is nothing we can do here other then logging the error, right?