### PR TITLE
Fix translations

### DIFF
--- a/assets/i18n/active.de.json
+++ b/assets/i18n/active.de.json
@@ -85,7 +85,7 @@
     "other": "**Umfrage-Einstellungen**: {{.Settings}}"
   },
   "poll.message.totalVotes": {
-    "hash": "sha1-ea094ab4bcf8b514e19bd2ba1daa56f23016c777",
+    "hash": "sha1-9a86d661838edccd7408678f9c1bb65de3d889c0",
     "other": "**Anzahl der abgegeben Stimmen**: {{.TotalVotes}}"
   },
   "response.addOption.invalidPermission": {

--- a/assets/i18n/active.en.json
+++ b/assets/i18n/active.en.json
@@ -23,7 +23,7 @@
   "poll.endPost.seperator": "and",
   "poll.endPost.text": "This poll has ended. The results are:",
   "poll.message.pollSettings": "**Poll Settings**: {{.Settings}}",
-  "poll.message.totalVotes": "**Total Votes**: {{.TotalVotes}}",
+  "poll.message.totalVotes": "**Total votes**: {{.TotalVotes}}",
   "response.addOption.invalidPermission": "Only the creator of a poll and System Admins are allowed to add options.",
   "response.addOption.success": "Successfully added the option.",
   "response.deletePoll.invalidPermission": "Only the creator of a poll and System Admins are allowed to delete it.",

--- a/assets/i18n/active.fr.json
+++ b/assets/i18n/active.fr.json
@@ -85,7 +85,7 @@
     "other": "**Paramètres du sondage**: {{.Settings}}"
   },
   "poll.message.totalVotes": {
-    "hash": "sha1-ea094ab4bcf8b514e19bd2ba1daa56f23016c777",
+    "hash": "sha1-9a86d661838edccd7408678f9c1bb65de3d889c0",
     "other": "**Total des votes**: {{.TotalVotes}}"
   },
   "response.addOption.invalidPermission": {

--- a/assets/i18n/active.fr.json
+++ b/assets/i18n/active.fr.json
@@ -21,7 +21,7 @@
   },
   "command.help.text.options": {
     "hash": "sha1-9576f41168dfc7418562fad8a5e82f309014c344",
-    "other": "Vous pouvez personnaliser les options en tapant `/{{.Trigger}} \\\"Question\\\" \\\"Réponse 1\\\" \\\"Réponse 2\\\" \\\"Réponse 3\\\"`"
+    "other": "Vous pouvez personnaliser les options en tapant `/{{.Trigger}} \"Question\" \"Réponse 1\" \"Réponse 2\" \"Réponse 3\"`"
   },
   "command.help.text.pollSetting.anonymous": {
     "hash": "sha1-fb98b7ba3c20091f6ea79a47ee43122d14e3f50a",
@@ -29,7 +29,7 @@
   },
   "command.help.text.pollSetting.introduction": {
     "hash": "sha1-2484e1a47494f152cf4e3d96bd173da1a779ac30",
-    "other": "Les paramètres du sondage permettent une personnalisation plus poussée, e.g. `/{{.Trigger}} \\\"Question\\\" \\\"Réponse 1\\\" \\\"Réponse 2\\\" \\\"Réponse 3\\\" --progress --anonymous`. Les éléments de configuration disponibles sont :"
+    "other": "Les paramètres du sondage permettent une personnalisation plus poussée, e.g. `/{{.Trigger}} \"Question\" \"Réponse 1\" \"Réponse 2\" \"Réponse 3\" --progress --anonymous`. Les éléments de configuration disponibles sont :"
   },
   "command.help.text.pollSetting.progress": {
     "hash": "sha1-9b8deba20f6a2fc6221841de9db19c903d28f97f",
@@ -41,7 +41,7 @@
   },
   "command.help.text.simple": {
     "hash": "sha1-3e9e692901434c94972562861477a71bf6dda12e",
-    "other": "Pour créer un sondage avec les réponses \\\"{{.Yes}}\\\" et \\\"{{.No}}\\\" tapez `/{{.Trigger}} \\\"Question\\\"`."
+    "other": "Pour créer un sondage avec les réponses \"{{.Yes}}\" et \"{{.No}}\" tapez `/{{.Trigger}} \"Question\"`."
   },
   "dialog.addOption.element.displayName": {
     "hash": "sha1-e31d972229de381b461860014dd710856361917a",

--- a/assets/i18n/active.ja.json
+++ b/assets/i18n/active.ja.json
@@ -21,7 +21,7 @@
   },
   "command.help.text.options": {
     "hash": "sha1-9576f41168dfc7418562fad8a5e82f309014c344",
-    "other": "`/{{.Trigger}} \\\"Question\\\" \\\"Answer 1\\\" \\\"Answer 2\\\" \\\"Answer 3\\\"`のように入力することで、回答をカスタマイズすることができます。"
+    "other": "`/{{.Trigger}} \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\"`のように入力することで、回答をカスタマイズすることができます。"
   },
   "command.help.text.pollSetting.anonymous": {
     "hash": "sha1-fb98b7ba3c20091f6ea79a47ee43122d14e3f50a",
@@ -29,7 +29,7 @@
   },
   "command.help.text.pollSetting.introduction": {
     "hash": "sha1-2484e1a47494f152cf4e3d96bd173da1a779ac30",
-    "other": "投票に関する設定を行うことができます。例: `/{{.Trigger}} \\\"Question\\\" \\\"Answer 1\\\" \\\"Answer 2\\\" \\\"Answer 3\\\" --progress --anonymous`. 利用可能な設定:"
+    "other": "投票に関する設定を行うことができます。例: `/{{.Trigger}} \"Question\" \"Answer 1\" \"Answer 2\" \"Answer 3\" --progress --anonymous`. 利用可能な設定:"
   },
   "command.help.text.pollSetting.progress": {
     "hash": "sha1-9b8deba20f6a2fc6221841de9db19c903d28f97f",
@@ -41,7 +41,7 @@
   },
   "command.help.text.simple": {
     "hash": "sha1-3e9e692901434c94972562861477a71bf6dda12e",
-    "other": "\\\"{{.Yes}}\\\" と \\\"{{.No}}\\\" を回答とする投票を作成するには `/{{.Trigger}} \\\"Question\\\"` と入力してください。"
+    "other": "\"{{.Yes}}\" と \"{{.No}}\" を回答とする投票を作成するには `/{{.Trigger}} \"Question\"` と入力してください。"
   },
   "dialog.addOption.element.displayName": {
     "hash": "sha1-e31d972229de381b461860014dd710856361917a",
@@ -84,7 +84,7 @@
     "other": "**投票の設定**: {{.Settings}}"
   },
   "poll.message.totalVotes": {
-    "hash": "sha1-ea094ab4bcf8b514e19bd2ba1daa56f23016c777",
+    "hash": "sha1-9a86d661838edccd7408678f9c1bb65de3d889c0",
     "other": "**総投票数**: {{.TotalVotes}}"
   },
   "response.addOption.invalidPermission": {


### PR DESCRIPTION
This PR fixes two things:
- Update `poll.message.totalVotes` as I forgot to pull the new translation from the source file
- Fix the double escaped `\` in `fr` and `ja` translation. See https://github.com/nicksnyder/go-i18n/issues/160 for more details.