### PR TITLE
Trim space when checking duplication

### DIFF
--- a/server/poll/poll.go
+++ b/server/poll/poll.go
@@ -60,13 +60,14 @@ func NewPoll(creator, question string, answerOptions, settings []string) (*Poll,
 	return &p, nil
 }
 
-// AddAnswerOption adds a new aAnswerOption to a poll
+// AddAnswerOption adds a new AnswerOption to a poll
 func (p *Poll) AddAnswerOption(newAnswerOption string) error {
+	newAnswerOption = strings.TrimSpace(newAnswerOption)
 	if newAnswerOption == "" {
 		return errors.New("empty option not allowed")
 	}
 	for _, answerOption := range p.AnswerOptions {
-		if strings.Trim(answerOption.Answer, " ") == strings.Trim(newAnswerOption, " ") {
+		if answerOption.Answer == newAnswerOption {
 			return fmt.Errorf("duplicate options: %s", newAnswerOption)
 		}
 	}

--- a/server/poll/poll.go
+++ b/server/poll/poll.go
@@ -3,6 +3,7 @@ package poll
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/pkg/errors"
@@ -65,7 +66,7 @@ func (p *Poll) AddAnswerOption(newAnswerOption string) error {
 		return errors.New("empty option not allowed")
 	}
 	for _, answerOption := range p.AnswerOptions {
-		if answerOption.Answer == newAnswerOption {
+		if strings.Trim(answerOption.Answer, " ") == strings.Trim(newAnswerOption, " ") {
 			return fmt.Errorf("duplicate options: %s", newAnswerOption)
 		}
 	}

--- a/server/poll/poll_test.go
+++ b/server/poll/poll_test.go
@@ -1,6 +1,7 @@
 package poll_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/bouk/monkey"
@@ -75,6 +76,12 @@ func TestAddAnswerOption(t *testing.T) {
 		p := testutils.GetPollWithVotes()
 
 		err := p.AddAnswerOption(p.AnswerOptions[0].Answer)
+		assert.NotNil(err)
+	})
+	t.Run("dublicant options with spaces", func(t *testing.T) {
+		p := testutils.GetPollWithVotes()
+
+		err := p.AddAnswerOption(fmt.Sprintf(" %s ", p.AnswerOptions[0].Answer))
 		assert.NotNil(err)
 	})
 	t.Run("empty options", func(t *testing.T) {

--- a/server/poll/poll_test.go
+++ b/server/poll/poll_test.go
@@ -90,6 +90,12 @@ func TestAddAnswerOption(t *testing.T) {
 		err := p.AddAnswerOption("")
 		assert.NotNil(err)
 	})
+	t.Run("empty optinos with spaces", func(t *testing.T) {
+		p := testutils.GetPollWithVotes()
+
+		err := p.AddAnswerOption("  ")
+		assert.NotNil(err)
+	})
 }
 
 func TestEncodeDecode(t *testing.T) {


### PR DESCRIPTION
Existing duplication check considers `No` and `No `(with trainling space) as different option.
It should be considered as same.

![スクリーンショット 2019-05-30 23 53 47](https://user-images.githubusercontent.com/1453749/58641560-63f53e00-8336-11e9-98e8-f0d76d2a0732.png)

