### PR TITLE
Refactor api.go

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -140,10 +140,10 @@ func (p *MatterpollPlugin) handlePostActionIntegrationRequest(handler postAction
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
 		if _, err = w.Write(response.ToJson()); err != nil {
 			p.API.LogWarn("failed to write PostActionIntegrationResponse", "error", err.Error())
 		}
+		w.WriteHeader(http.StatusOK)
 	}
 }
 
@@ -166,11 +166,13 @@ func (p *MatterpollPlugin) handleSubmitDialogRequest(handler submitDialogHandler
 			p.SendEphemeralPost(request.ChannelId, request.UserId, p.LocalizeDefaultMessage(userLocalizer, msg))
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		if _, err = w.Write(response.ToJson()); err != nil {
-			p.API.LogWarn("failed to write PostActionIntegrationResponse", "error", err.Error())
+		if response != nil {
+			w.Header().Set("Content-Type", "application/json")
+			if _, err = w.Write(response.ToJson()); err != nil {
+				p.API.LogWarn("failed to write SubmitDialogRequest", "error", err.Error())
+			}
 		}
+		w.WriteHeader(http.StatusOK)
 	}
 }
 

--- a/server/plugin/api_test.go
+++ b/server/plugin/api_test.go
@@ -237,7 +237,6 @@ func TestHandleVote(t *testing.T) {
 		"Valid request, GetUser fails": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
 				api.On("GetUser", "userID1").Return(nil, &model.AppError{})
-				api.On("LogWarn", GetMockArgumentsWithType("string", 3)...).Return()
 				return api
 			},
 			SetupStore: func(store *mockstore.Store) *mockstore.Store {
@@ -255,6 +254,7 @@ func TestHandleVote(t *testing.T) {
 
 			api := test.SetupAPI(&plugintest.API{})
 			api.On("LogDebug", GetMockArgumentsWithType("string", 7)...).Return()
+			api.On("LogWarn", GetMockArgumentsWithType("string", 3)...).Return().Maybe()
 			defer api.AssertExpectations(t)
 			store := test.SetupStore(&mockstore.Store{})
 			defer store.AssertExpectations(t)
@@ -414,7 +414,6 @@ func TestHandleAddOptionDialogRequest(t *testing.T) {
 		"Valid request, OpenInteractiveDialog fails": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
 				api.On("OpenInteractiveDialog", dialogRequest).Return(&model.AppError{})
-				api.On("LogError", GetMockArgumentsWithType("string", 3)...).Return(nil)
 				return api
 			},
 			SetupStore: func(store *mockstore.Store) *mockstore.Store {
@@ -435,6 +434,7 @@ func TestHandleAddOptionDialogRequest(t *testing.T) {
 
 			api := test.SetupAPI(&plugintest.API{})
 			api.On("LogDebug", GetMockArgumentsWithType("string", 7)...).Return()
+			api.On("LogWarn", GetMockArgumentsWithType("string", 3)...).Return().Maybe()
 			api.On("GetUser", userID).Return(&model.User{FirstName: "John", LastName: "Doe"}, nil)
 			defer api.AssertExpectations(t)
 			store := test.SetupStore(&mockstore.Store{})
@@ -588,7 +588,6 @@ func TestHandleEndPoll(t *testing.T) {
 		"Valid request, GetUser fails for poll creator": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
 				api.On("GetUser", "userID1").Return(nil, &model.AppError{})
-				api.On("LogWarn", GetMockArgumentsWithType("string", 3)...).Return()
 				return api
 			},
 			SetupStore: func(store *mockstore.Store) *mockstore.Store {
@@ -626,6 +625,7 @@ func TestHandleEndPoll(t *testing.T) {
 
 			api := test.SetupAPI(&plugintest.API{})
 			api.On("LogDebug", GetMockArgumentsWithType("string", 7)...).Return()
+			api.On("LogWarn", GetMockArgumentsWithType("string", 3)...).Return().Maybe()
 			defer api.AssertExpectations(t)
 			store := test.SetupStore(&mockstore.Store{})
 			defer store.AssertExpectations(t)
@@ -676,7 +676,6 @@ func TestPostEndPollAnnouncement(t *testing.T) {
 								"Question": "Question",
 								"Link":     "https://example.org/team1/pl/postID1",
 							}}),
-
 					Type: model.POST_DEFAULT,
 				}).Return(nil, nil)
 				return api
@@ -840,6 +839,7 @@ func TestHandleDeletePoll(t *testing.T) {
 
 			api := test.SetupAPI(&plugintest.API{})
 			api.On("LogDebug", GetMockArgumentsWithType("string", 7)...).Return()
+			api.On("LogWarn", GetMockArgumentsWithType("string", 3)...).Return().Maybe()
 			defer api.AssertExpectations(t)
 			store := test.SetupStore(&mockstore.Store{})
 			defer store.AssertExpectations(t)

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -12,8 +12,7 @@ import (
 
 const (
 	// Parameter: SiteURL, PluginId
-	responseIconURL  = "%s/plugins/%s/logo_dark.png"
-	responseUsername = "Matterpoll"
+	responseIconURL = "%s/plugins/%s/logo_dark.png"
 )
 
 var (

--- a/server/plugin/plugin_test.go
+++ b/server/plugin/plugin_test.go
@@ -53,7 +53,8 @@ func TestPluginOnActivate(t *testing.T) {
 		"greater minor version than minimumServerVersion": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
 				m := semver.MustParse(minimumServerVersion)
-				m.IncrementMinor()
+				err := m.IncrementMinor()
+				require.NoError(t, err)
 				api.On("GetServerVersion").Return(m.String())
 
 				path, err := filepath.Abs("../..")


### PR DESCRIPTION
This PR refactors `api.go` to be much more DRY and unify handling of `PostActionIntegrationRequest` and `SubmitDialogRequest`. The only functional change is that error thrown from the http handlers will now be logged. The log level is `warning`.