### PR TITLE
Downstream mattermost-plugin-starter-template

### DIFF
--- a/build/custom.mk
+++ b/build/custom.mk
@@ -1,0 +1,9 @@
+# Include custome targets and environment variables here
+
+GO_TEST_FLAGS = -race -gcflags=-l
+.DEFAULT_GOAL := all
+
+## Generate store mocks
+.PHONY: store-mocks
+store-mocks:
+	mockery -name=".Store" -dir server/store -output server/store/mockstore/mocks -note 'Regenerate this file using `make store-mocks`.'

--- a/build/manifest/main.go
+++ b/build/manifest/main.go
@@ -10,18 +10,18 @@ import (
 	"github.com/pkg/errors"
 )
 
-const pluginIdGoFileTemplate = `package plugin
+const pluginIDGoFileTemplate = `package plugin
 
 var manifest = struct {
-	Id      string
+	ID      string
 	Version string
 }{
-	Id:      "%s",
+	ID:      "%s",
 	Version: "%s",
 }
 `
 
-const pluginIdJsFileTemplate = `export const id = '%s';
+const pluginIDJSFileTemplate = `export const id = '%s';
 export const version = '%s';
 `
 
@@ -38,7 +38,7 @@ func main() {
 	cmd := os.Args[1]
 	switch cmd {
 	case "id":
-		dumpPluginId(manifest)
+		dumpPluginID(manifest)
 
 	case "version":
 		dumpPluginVersion(manifest)
@@ -87,7 +87,7 @@ func findManifest() (*model.Manifest, error) {
 }
 
 // dumpPluginId writes the plugin id from the given manifest to standard out
-func dumpPluginId(manifest *model.Manifest) {
+func dumpPluginID(manifest *model.Manifest) {
 	fmt.Printf("%s", manifest.Id)
 }
 
@@ -101,7 +101,7 @@ func applyManifest(manifest *model.Manifest) error {
 	if manifest.HasServer() {
 		if err := ioutil.WriteFile(
 			"server/plugin/manifest.go",
-			[]byte(fmt.Sprintf(pluginIdGoFileTemplate, manifest.Id, manifest.Version)),
+			[]byte(fmt.Sprintf(pluginIDGoFileTemplate, manifest.Id, manifest.Version)),
 			0644,
 		); err != nil {
 			return errors.Wrap(err, "failed to write server/manifest.go")
@@ -111,7 +111,7 @@ func applyManifest(manifest *model.Manifest) error {
 	if manifest.HasWebapp() {
 		if err := ioutil.WriteFile(
 			"webapp/src/manifest.js",
-			[]byte(fmt.Sprintf(pluginIdJsFileTemplate, manifest.Id, manifest.Version)),
+			[]byte(fmt.Sprintf(pluginIDJSFileTemplate, manifest.Id, manifest.Version)),
 			0644,
 		); err != nil {
 			return errors.Wrap(err, "failed to open webapp/src/manifest.js")

--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -26,7 +26,7 @@ type (
 )
 
 var (
-	infoMessage = "Thanks for using Matterpoll v" + manifest.Id + "\n"
+	infoMessage = "Thanks for using Matterpoll v" + manifest.ID + "\n"
 
 	responseVoteCounted = &i18n.Message{
 		ID:    "response.vote.counted",
@@ -214,7 +214,7 @@ func (p *MatterpollPlugin) handleVote(vars map[string]string, request *model.Pos
 
 	post := &model.Post{}
 	publicLocalizer := p.getServerLocalizer()
-	model.ParseSlackAttachment(post, poll.ToPostActions(publicLocalizer, *p.ServerConfig.ServiceSettings.SiteURL, manifest.Id, displayName))
+	model.ParseSlackAttachment(post, poll.ToPostActions(publicLocalizer, *p.ServerConfig.ServiceSettings.SiteURL, manifest.ID, displayName))
 
 	if hasVoted {
 		return responseVoteUpdated, post, nil
@@ -255,7 +255,7 @@ func (p *MatterpollPlugin) handleAddOption(vars map[string]string, request *mode
 	}
 
 	publicLocalizer := p.getServerLocalizer()
-	model.ParseSlackAttachment(post, poll.ToPostActions(publicLocalizer, *p.ServerConfig.ServiceSettings.SiteURL, manifest.Id, displayName))
+	model.ParseSlackAttachment(post, poll.ToPostActions(publicLocalizer, *p.ServerConfig.ServiceSettings.SiteURL, manifest.ID, displayName))
 	if _, appErr = p.API.UpdatePost(post); appErr != nil {
 		return commandErrorGeneric, nil, errors.Wrap(appErr, "failed to update post")
 	}
@@ -290,10 +290,10 @@ func (p *MatterpollPlugin) handleAddOptionDialogRequest(vars map[string]string, 
 	siteURL := *p.ServerConfig.ServiceSettings.SiteURL
 	dialog := model.OpenDialogRequest{
 		TriggerId: request.TriggerId,
-		URL:       fmt.Sprintf("%s/plugins/%s/api/v1/polls/%s/option/add", siteURL, manifest.Id, pollID),
+		URL:       fmt.Sprintf("%s/plugins/%s/api/v1/polls/%s/option/add", siteURL, manifest.ID, pollID),
 		Dialog: model.Dialog{
 			Title:       p.LocalizeDefaultMessage(userLocalizer, dialogAddOptionTitle),
-			IconURL:     fmt.Sprintf(responseIconURL, siteURL, manifest.Id),
+			IconURL:     fmt.Sprintf(responseIconURL, siteURL, manifest.ID),
 			CallbackId:  request.PostId,
 			SubmitLabel: p.LocalizeDefaultMessage(userLocalizer, dialogAddOptionSubmitLabel),
 			Elements: []model.DialogElement{{

--- a/server/plugin/api_test.go
+++ b/server/plugin/api_test.go
@@ -144,7 +144,7 @@ func TestHandleVote(t *testing.T) {
 	err := poll1Out.UpdateVote("userID1", 0)
 	require.Nil(t, err)
 	expectedPost1 := &model.Post{}
-	model.ParseSlackAttachment(expectedPost1, poll1Out.ToPostActions(localizer, testutils.GetSiteURL(), manifest.Id, "John Doe"))
+	model.ParseSlackAttachment(expectedPost1, poll1Out.ToPostActions(localizer, testutils.GetSiteURL(), manifest.ID, "John Doe"))
 
 	poll2In := testutils.GetPoll()
 	err = poll2In.UpdateVote("userID1", 0)
@@ -153,7 +153,7 @@ func TestHandleVote(t *testing.T) {
 	err = poll2Out.UpdateVote("userID1", 1)
 	require.Nil(t, err)
 	expectedPost2 := &model.Post{}
-	model.ParseSlackAttachment(expectedPost2, poll2Out.ToPostActions(localizer, testutils.GetSiteURL(), manifest.Id, "John Doe"))
+	model.ParseSlackAttachment(expectedPost2, poll2Out.ToPostActions(localizer, testutils.GetSiteURL(), manifest.ID, "John Doe"))
 
 	for name, test := range map[string]struct {
 		SetupAPI           func(*plugintest.API) *plugintest.API
@@ -332,7 +332,7 @@ func TestHandleAddOption(t *testing.T) {
 	err := poll1Out.AddAnswerOption("New Option")
 	require.Nil(t, err)
 	expectedPost1 := &model.Post{}
-	model.ParseSlackAttachment(expectedPost1, poll1Out.ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), manifest.Id, "John Doe"))
+	model.ParseSlackAttachment(expectedPost1, poll1Out.ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), manifest.ID, "John Doe"))
 
 	for name, test := range map[string]struct {
 		SetupAPI           func(*plugintest.API) *plugintest.API
@@ -418,10 +418,10 @@ func TestHandleAddOptionDialogRequest(t *testing.T) {
 
 	dialogRequest := model.OpenDialogRequest{
 		TriggerId: triggerID,
-		URL:       fmt.Sprintf("%s/plugins/%s/api/v1/polls/%s/option/add", testutils.GetSiteURL(), manifest.Id, testutils.GetPollID()),
+		URL:       fmt.Sprintf("%s/plugins/%s/api/v1/polls/%s/option/add", testutils.GetSiteURL(), manifest.ID, testutils.GetPollID()),
 		Dialog: model.Dialog{
 			Title:       "Add Option",
-			IconURL:     fmt.Sprintf(responseIconURL, testutils.GetSiteURL(), manifest.Id),
+			IconURL:     fmt.Sprintf(responseIconURL, testutils.GetSiteURL(), manifest.ID),
 			CallbackId:  postID,
 			SubmitLabel: "Add",
 			Elements: []model.DialogElement{{

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	// Parameter: SiteURL, manifest.Id
+	// Parameter: SiteURL, manifest.ID
 	responseIconURL = "%s/plugins/%s/logo_dark.png"
 )
 
@@ -151,7 +151,7 @@ func (p *MatterpollPlugin) executeCommand(args *model.CommandArgs) (string, *mod
 		return p.LocalizeDefaultMessage(userLocalizer, commandErrorGeneric), nil
 	}
 
-	actions := newPoll.ToPostActions(publicLocalizer, *p.ServerConfig.ServiceSettings.SiteURL, manifest.Id, displayName)
+	actions := newPoll.ToPostActions(publicLocalizer, *p.ServerConfig.ServiceSettings.SiteURL, manifest.ID, displayName)
 	post := &model.Post{
 		UserId:    p.botUserID,
 		ChannelId: args.ChannelId,

--- a/server/plugin/command_test.go
+++ b/server/plugin/command_test.go
@@ -59,7 +59,7 @@ func TestPluginExecuteCommand(t *testing.T) {
 					RootId:    "postID1",
 					Type:      model.POST_DEFAULT,
 				}
-				actions := testutils.GetPollTwoOptions().ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), manifest.Id, "John Doe")
+				actions := testutils.GetPollTwoOptions().ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), manifest.ID, "John Doe")
 				model.ParseSlackAttachment(post, actions)
 				api.On("CreatePost", post).Return(post, nil)
 				return api
@@ -80,7 +80,7 @@ func TestPluginExecuteCommand(t *testing.T) {
 					RootId:    "postID1",
 					Type:      model.POST_DEFAULT,
 				}
-				actions := testutils.GetPollTwoOptions().ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), manifest.Id, "John Doe")
+				actions := testutils.GetPollTwoOptions().ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), manifest.ID, "John Doe")
 				model.ParseSlackAttachment(post, actions)
 				api.On("CreatePost", post).Return(nil, &model.AppError{})
 				api.On("LogError", GetMockArgumentsWithType("string", 3)...).Return()
@@ -104,7 +104,7 @@ func TestPluginExecuteCommand(t *testing.T) {
 					RootId:    "postID1",
 					Type:      model.POST_DEFAULT,
 				}
-				actions := testutils.GetPoll().ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), manifest.Id, "John Doe")
+				actions := testutils.GetPoll().ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), manifest.ID, "John Doe")
 				model.ParseSlackAttachment(post, actions)
 				api.On("CreatePost", post).Return(post, nil)
 				return api
@@ -126,7 +126,7 @@ func TestPluginExecuteCommand(t *testing.T) {
 					RootId:    "postID1",
 					Type:      model.POST_DEFAULT,
 				}
-				actions := testutils.GetPollWithSettings(poll.PollSettings{Progress: true}).ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), manifest.Id, "John Doe")
+				actions := testutils.GetPollWithSettings(poll.PollSettings{Progress: true}).ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), manifest.ID, "John Doe")
 				model.ParseSlackAttachment(post, actions)
 				api.On("CreatePost", post).Return(post, nil)
 				return api
@@ -149,7 +149,7 @@ func TestPluginExecuteCommand(t *testing.T) {
 					RootId:    "postID1",
 					Type:      model.POST_DEFAULT,
 				}
-				actions := testutils.GetPollWithSettings(poll.PollSettings{Progress: true, Anonymous: true}).ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), manifest.Id, "John Doe")
+				actions := testutils.GetPollWithSettings(poll.PollSettings{Progress: true, Anonymous: true}).ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), manifest.ID, "John Doe")
 				model.ParseSlackAttachment(post, actions)
 				api.On("CreatePost", post).Return(post, nil)
 				return api

--- a/server/plugin/command_test.go
+++ b/server/plugin/command_test.go
@@ -126,13 +126,13 @@ func TestPluginExecuteCommand(t *testing.T) {
 					RootId:    "postID1",
 					Type:      model.POST_DEFAULT,
 				}
-				actions := testutils.GetPollWithSettings(poll.PollSettings{Progress: true}).ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), manifest.ID, "John Doe")
+				actions := testutils.GetPollWithSettings(poll.Settings{Progress: true}).ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), manifest.ID, "John Doe")
 				model.ParseSlackAttachment(post, actions)
 				api.On("CreatePost", post).Return(post, nil)
 				return api
 			},
 			SetupStore: func(store *mockstore.Store) *mockstore.Store {
-				poll := testutils.GetPollWithSettings(poll.PollSettings{Progress: true})
+				poll := testutils.GetPollWithSettings(poll.Settings{Progress: true})
 				store.PollStore.On("Save", poll).Return(nil)
 				return store
 			},
@@ -149,13 +149,13 @@ func TestPluginExecuteCommand(t *testing.T) {
 					RootId:    "postID1",
 					Type:      model.POST_DEFAULT,
 				}
-				actions := testutils.GetPollWithSettings(poll.PollSettings{Progress: true, Anonymous: true}).ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), manifest.ID, "John Doe")
+				actions := testutils.GetPollWithSettings(poll.Settings{Progress: true, Anonymous: true}).ToPostActions(testutils.GetLocalizer(), testutils.GetSiteURL(), manifest.ID, "John Doe")
 				model.ParseSlackAttachment(post, actions)
 				api.On("CreatePost", post).Return(post, nil)
 				return api
 			},
 			SetupStore: func(store *mockstore.Store) *mockstore.Store {
-				poll := testutils.GetPollWithSettings(poll.PollSettings{Progress: true, Anonymous: true})
+				poll := testutils.GetPollWithSettings(poll.Settings{Progress: true, Anonymous: true})
 				store.PollStore.On("Save", poll).Return(nil)
 				return store
 			},

--- a/server/plugin/manifest.go
+++ b/server/plugin/manifest.go
@@ -1,9 +1,9 @@
 package plugin
 
 var manifest = struct {
-	Id      string
+	ID      string
 	Version string
 }{
-	Id:      "com.github.matterpoll.matterpoll",
+	ID:      "com.github.matterpoll.matterpoll",
 	Version: "1.1.0",
 }

--- a/server/poll/poll.go
+++ b/server/poll/poll.go
@@ -16,7 +16,7 @@ type Poll struct {
 	Creator       string
 	Question      string
 	AnswerOptions []*AnswerOption
-	Settings      PollSettings
+	Settings      Settings
 }
 
 // AnswerOption stores a possible answer and a list of user who voted for this
@@ -25,8 +25,8 @@ type AnswerOption struct {
 	Voter  []string
 }
 
-// PollSettings stores possible settings for a poll
-type PollSettings struct {
+// Settings stores possible settings for a poll
+type Settings struct {
 	Anonymous       bool
 	Progress        bool
 	PublicAddOption bool

--- a/server/poll/poll_test.go
+++ b/server/poll/poll_test.go
@@ -34,7 +34,7 @@ func TestNewPoll(t *testing.T) {
 		assert.Equal(&poll.AnswerOption{Answer: answerOptions[0], Voter: nil}, p.AnswerOptions[0])
 		assert.Equal(&poll.AnswerOption{Answer: answerOptions[1], Voter: nil}, p.AnswerOptions[1])
 		assert.Equal(&poll.AnswerOption{Answer: answerOptions[2], Voter: nil}, p.AnswerOptions[2])
-		assert.Equal(poll.PollSettings{Anonymous: true, Progress: true, PublicAddOption: true}, p.Settings)
+		assert.Equal(poll.Settings{Anonymous: true, Progress: true, PublicAddOption: true}, p.Settings)
 	})
 	t.Run("error, unknown setting", func(t *testing.T) {
 		assert := assert.New(t)

--- a/server/poll/transform.go
+++ b/server/poll/transform.go
@@ -22,7 +22,7 @@ var (
 		Other: "End Poll",
 	}
 
-	pollMessagePollSettings = &i18n.Message{
+	pollMessageSettings = &i18n.Message{
 		ID:    "poll.message.pollSettings",
 		Other: "**Poll Settings**: {{.Settings}}",
 	}
@@ -115,7 +115,7 @@ func (p *Poll) makeAdditionalText(localizer *i18n.Localizer, numberOfVotes int) 
 	lines := []string{"---"}
 	if len(settingsText) > 0 {
 		lines = append(lines, localizer.MustLocalize(&i18n.LocalizeConfig{
-			DefaultMessage: pollMessagePollSettings,
+			DefaultMessage: pollMessageSettings,
 			TemplateData:   map[string]interface{}{"Settings": strings.Join(settingsText, ", ")},
 		}))
 	}

--- a/server/poll/transform_test.go
+++ b/server/poll/transform_test.go
@@ -53,7 +53,7 @@ func TestPollToEndPollPost(t *testing.T) {
 			}},
 		},
 		"Anonymous poll": {
-			Poll: testutils.GetPollWithVotesAndSettings(poll.PollSettings{Anonymous: true}),
+			Poll: testutils.GetPollWithVotesAndSettings(poll.Settings{Anonymous: true}),
 			ExpectedAttachments: []*model.SlackAttachment{{
 				AuthorName: "John Doe",
 				Title:      "Question",
@@ -147,7 +147,7 @@ func TestPollToPostActions(t *testing.T) {
 			}},
 		},
 		"Multipile questions, settings: progress": {
-			Poll: testutils.GetPollWithSettings(poll.PollSettings{Progress: true}),
+			Poll: testutils.GetPollWithSettings(poll.Settings{Progress: true}),
 			ExpectedAttachments: []*model.SlackAttachment{{
 				AuthorName: "John Doe",
 				Title:      "Question",
@@ -193,7 +193,7 @@ func TestPollToPostActions(t *testing.T) {
 			}},
 		},
 		"Multipile questions, settings: anonymous, public-add-option": {
-			Poll: testutils.GetPollWithSettings(poll.PollSettings{Anonymous: true, PublicAddOption: true}),
+			Poll: testutils.GetPollWithSettings(poll.Settings{Anonymous: true, PublicAddOption: true}),
 			ExpectedAttachments: []*model.SlackAttachment{{
 				AuthorName: "John Doe",
 				Title:      "Question",

--- a/server/store/mockstore/store.go
+++ b/server/store/mockstore/store.go
@@ -6,14 +6,19 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// Store is a mock store
 type Store struct {
 	PollStore   mocks.PollStore
 	SystemStore mocks.SystemStore
 }
 
-func (s *Store) Poll() store.PollStore     { return &s.PollStore }
+// Poll returns the Poll Store
+func (s *Store) Poll() store.PollStore { return &s.PollStore }
+
+// System returns the System Store
 func (s *Store) System() store.SystemStore { return &s.SystemStore }
 
+// AssertExpectations makes sure the expectations of all stores are meet
 func (s *Store) AssertExpectations(t mock.TestingT) {
 	s.PollStore.AssertExpectations(t)
 	s.SystemStore.AssertExpectations(t)

--- a/server/utils/testutils/data.go
+++ b/server/utils/testutils/data.go
@@ -50,7 +50,7 @@ func GetPoll() *poll.Poll {
 }
 
 // GetPollWithSettings returns a Poll with three Options, no votes and given Poll Settings.
-func GetPollWithSettings(settings poll.PollSettings) *poll.Poll {
+func GetPollWithSettings(settings poll.Settings) *poll.Poll {
 	poll := GetPoll()
 	poll.Settings = settings
 	return poll
@@ -74,7 +74,7 @@ func GetPollWithVotes() *poll.Poll {
 }
 
 // GetPollWithVotesAndSettings returns a Poll with three Options, some votes and given Poll Settings.
-func GetPollWithVotesAndSettings(settings poll.PollSettings) *poll.Poll {
+func GetPollWithVotesAndSettings(settings poll.Settings) *poll.Poll {
 	poll := GetPollWithVotes()
 	poll.Settings = settings
 	return poll


### PR DESCRIPTION
This PR downstreams the latest changes from https://github.com/mattermost/mattermost-plugin-starter-template. Notable are:
- Custom makefile changes are now in `build/custom.mk`
- `check-style` also checks for `golint` compliance
- Renamed `PollSettings` to `Settings`. I've tested with an older version and this isn't a breaking change. But please double check and test. 