### PR TITLE
MM-17366: handle curly quotes when parsing

### DIFF
--- a/server/utils/utils.go
+++ b/server/utils/utils.go
@@ -9,6 +9,16 @@ import (
 func ParseInput(input string, trigger string) (string, []string, []string) {
 	settings := []string{}
 
+	// Transform curly quotes to straight quotes
+	input = strings.Map(func(in rune) rune {
+		switch in {
+		case '“', '”':
+			return '"'
+		}
+
+		return in
+	}, input)
+
 	// Remove Trigger prefix and spaces
 	in := strings.TrimSpace(strings.TrimPrefix(input, fmt.Sprintf("/%s", trigger)))
 	// Remove first "

--- a/server/utils/utils_test.go
+++ b/server/utils/utils_test.go
@@ -43,6 +43,13 @@ func TestParseInput(t *testing.T) {
 			ExpectedOptions:  []string{"B", "C"},
 			ExpectedSettings: []string{},
 		},
+		"Replace curlyquotes": {
+			Input:            `/poll “A“ ”BBB” “CCC”`,
+			Trigger:          "poll",
+			ExpectedQuestion: `A`,
+			ExpectedOptions:  []string{"BBB", "CCC"},
+			ExpectedSettings: []string{},
+		},
 		"No options": {
 			Input:            `/poll  `,
 			Trigger:          "poll",


### PR DESCRIPTION
On iOS using an english keyboard, typing quotes yields curly quotes instead of straight quotes. Update the parser to handle these.

Fixes: https://mattermost.atlassian.net/browse/MM-17366