### PR TITLE
Use Default Client Language instead of Default Server Language

### DIFF
--- a/server/plugin/i18n.go
+++ b/server/plugin/i18n.go
@@ -56,9 +56,9 @@ func (p *MatterpollPlugin) getUserLocalizer(userID string) *i18n.Localizer {
 	return i18n.NewLocalizer(p.bundle, user.Locale)
 }
 
-// getServerLocalizer returns a localizer that localizes in the server default locale
+// getServerLocalizer returns a localizer that localizes in the server default client locale
 func (p *MatterpollPlugin) getServerLocalizer() *i18n.Localizer {
-	return i18n.NewLocalizer(p.bundle, *p.ServerConfig.LocalizationSettings.DefaultServerLocale)
+	return i18n.NewLocalizer(p.bundle, *p.ServerConfig.LocalizationSettings.DefaultClientLocale)
 }
 
 // LocalizeDefaultMessage localizer the provided message

--- a/server/plugin/plugin_test.go
+++ b/server/plugin/plugin_test.go
@@ -194,11 +194,11 @@ func TestPluginOnActivate(t *testing.T) {
 			defer patch.Unpatch()
 
 			siteURL := testutils.GetSiteURL()
-			defaultServerLocale := "en"
+			defaultClientLocale := "en"
 			p := &MatterpollPlugin{
 				ServerConfig: &model.Config{
 					LocalizationSettings: model.LocalizationSettings{
-						DefaultServerLocale: &defaultServerLocale,
+						DefaultClientLocale: &defaultClientLocale,
 					},
 					ServiceSettings: model.ServiceSettings{
 						SiteURL: &siteURL,

--- a/server/utils/testutils/data.go
+++ b/server/utils/testutils/data.go
@@ -23,13 +23,13 @@ func GetBotUserID() string {
 // GetServerConfig return a static server config.
 func GetServerConfig() *model.Config {
 	siteURL := GetSiteURL()
-	defaultServerLocale := "en"
+	defaultClientLocale := "en"
 	return &model.Config{
 		ServiceSettings: model.ServiceSettings{
 			SiteURL: &siteURL,
 		},
 		LocalizationSettings: model.LocalizationSettings{
-			DefaultServerLocale: &defaultServerLocale,
+			DefaultClientLocale: &defaultClientLocale,
 		},
 	}
 }


### PR DESCRIPTION
Per the MM docs  Default Client Language is used " for newly created users and pages where the user hasn’t logged in." (https://docs.mattermost.com/administration/config-settings.html#default-client-language), which fits our case much more.