### PR TITLE
Remove superfluous header call

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -164,7 +164,6 @@ func (p *MatterpollPlugin) handlePostActionIntegrationRequest(handler postAction
 		if _, err = w.Write(response.ToJson()); err != nil {
 			p.API.LogWarn("failed to write PostActionIntegrationResponse", "error", err.Error())
 		}
-		w.WriteHeader(http.StatusOK)
 	}
 }
 
@@ -193,7 +192,6 @@ func (p *MatterpollPlugin) handleSubmitDialogRequest(handler submitDialogHandler
 				p.API.LogWarn("failed to write SubmitDialogRequest", "error", err.Error())
 			}
 		}
-		w.WriteHeader(http.StatusOK)
 	}
 }
 


### PR DESCRIPTION
Otherwise the log is spammed with:

```
ERRO[2019-10-22T15:18:36.6914706+02:00] http: superfluous response.WriteHeader call from github.com/mattermost/mattermost-server/plugin.(*httpResponseWriterRPCServer).WriteHeader (http.go:27)  caller="http/server.go:3053" source=httpserver
```