### PR TITLE
Tweak golangci config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,6 @@ linters-settings:
   goconst:
     min-len: 2
     min-occurrences: 2
-  gocyclo:
-    min-complexity: 20
   gofmt:
     simplify: true
   golint:
@@ -11,6 +9,7 @@ linters-settings:
     min-confidence: 0.0
   govet:
     check-shadowing: true
+    enable-all: true
   misspell:
     locale: US
   maligned:
@@ -20,15 +19,19 @@ linters:
   enable:
     - bodyclose
     - goconst
-    - gocyclo
+    - gocritic
     - gofmt
     - goimports
     - golint
     - gosec
+    - interfacer
     - maligned
     - misspell
     - scopelint
+    - stylecheck
     - unconvert
+    - unparam
+    - whitespace
 
 issues:
   exclude-rules:
@@ -37,5 +40,4 @@ issues:
       linters:
         - dupl
         - goconst
-        - gocyclo
         - scopelint # https://github.com/kyoh86/scopelint/issues/4

--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -334,7 +334,6 @@ func (p *MatterpollPlugin) handleAddOptionConfirm(vars map[string]string, reques
 
 	if err = p.Store.Poll().Save(poll); err != nil {
 		return commandErrorGeneric, nil, errors.Wrap(err, "failed to get save poll")
-
 	}
 
 	return responseAddOptionSuccess, nil, nil

--- a/server/plugin/api_test.go
+++ b/server/plugin/api_test.go
@@ -164,7 +164,6 @@ func TestHandlePluginConfiguration(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestHandleVote(t *testing.T) {

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -54,8 +54,8 @@ const (
 
 // OnActivate ensures a configuration is set and initializes the API
 func (p *MatterpollPlugin) OnActivate() error {
-	var err error
-	if err = p.checkServerVersion(); err != nil {
+	err := p.checkServerVersion()
+	if err != nil {
 		return err
 	}
 

--- a/server/plugin/plugin_test.go
+++ b/server/plugin/plugin_test.go
@@ -21,7 +21,7 @@ import (
 	"golang.org/x/text/language"
 )
 
-func setupTestPlugin(_ *testing.T, api plugin.API, store store.Store) *MatterpollPlugin {
+func setupTestPlugin(_ *testing.T, api *plugintest.API, store *mockstore.Store) *MatterpollPlugin { //nolint:interfacer
 	p := &MatterpollPlugin{
 		ServerConfig: testutils.GetServerConfig(),
 	}

--- a/server/plugin/plugin_test.go
+++ b/server/plugin/plugin_test.go
@@ -21,7 +21,7 @@ import (
 	"golang.org/x/text/language"
 )
 
-func setupTestPlugin(t *testing.T, api *plugintest.API, store *mockstore.Store) *MatterpollPlugin {
+func setupTestPlugin(_ *testing.T, api plugin.API, store store.Store) *MatterpollPlugin {
 	p := &MatterpollPlugin{
 		ServerConfig: testutils.GetServerConfig(),
 	}


### PR DESCRIPTION
Adds some useful linters and hardens the config. I also removed `gocyclo` because it's not a good metric.

Requires #243