### PR TITLE
Don't report missing coverage as CI failure

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,11 @@
 ignore:
   - "server/main.go"
+
+coverage:
+    status:
+        project:
+            default:
+                informational: true
+        patch:
+            default:
+                informational: true


### PR DESCRIPTION
Decreasing coverage or missing coverage should not fail the CI. With these changes CI is always green for codecov.