### PR TITLE
Deep copy Voters

### DIFF
--- a/server/poll/poll.go
+++ b/server/poll/poll.go
@@ -192,7 +192,9 @@ func (p *Poll) Copy() *Poll {
 	for i, o := range p.AnswerOptions {
 		p2.AnswerOptions[i] = new(AnswerOption)
 		p2.AnswerOptions[i].Answer = o.Answer
-		// Only copy Voter if they are nil to ensure the new poll is an exact copy
+		// Only copy Voter if they are nil to ensure the new poll is an exact copy.
+		// Please note that polls fetched from the DB might have a nil value,
+		// hence we have to still think about this case in the future.
 		if o.Voter != nil {
 			p2.AnswerOptions[i].Voter = make([]string, len(o.Voter))
 			copy(p2.AnswerOptions[i].Voter, o.Voter)

--- a/server/poll/poll.go
+++ b/server/poll/poll.go
@@ -99,7 +99,11 @@ func (p *Poll) AddAnswerOption(newAnswerOption string) *ErrorMessage {
 			}
 		}
 	}
-	p.AnswerOptions = append(p.AnswerOptions, &AnswerOption{Answer: newAnswerOption})
+	ao := &AnswerOption{
+		Answer: newAnswerOption,
+		Voter:  []string{},
+	}
+	p.AnswerOptions = append(p.AnswerOptions, ao)
 	return nil
 }
 
@@ -180,7 +184,7 @@ func DecodePollFromByte(b []byte) *Poll {
 	return &p
 }
 
-// Copy deep copys a poll
+// Copy deep copies a poll
 func (p *Poll) Copy() *Poll {
 	p2 := new(Poll)
 	*p2 = *p
@@ -188,7 +192,11 @@ func (p *Poll) Copy() *Poll {
 	for i, o := range p.AnswerOptions {
 		p2.AnswerOptions[i] = new(AnswerOption)
 		p2.AnswerOptions[i].Answer = o.Answer
-		p2.AnswerOptions[i].Voter = o.Voter
+		// Only copy Voter if they are nil to ensure the new poll is an exact copy
+		if o.Voter != nil {
+			p2.AnswerOptions[i].Voter = make([]string, len(o.Voter))
+			copy(p2.AnswerOptions[i].Voter, o.Voter)
+		}
 	}
 	return p2
 }

--- a/server/poll/poll_test.go
+++ b/server/poll/poll_test.go
@@ -32,9 +32,9 @@ func TestNewPoll(t *testing.T) {
 		assert.Equal(int64(1234567890), p.CreatedAt)
 		assert.Equal(creator, p.Creator)
 		assert.Equal(question, p.Question)
-		assert.Equal(&poll.AnswerOption{Answer: answerOptions[0], Voter: nil}, p.AnswerOptions[0])
-		assert.Equal(&poll.AnswerOption{Answer: answerOptions[1], Voter: nil}, p.AnswerOptions[1])
-		assert.Equal(&poll.AnswerOption{Answer: answerOptions[2], Voter: nil}, p.AnswerOptions[2])
+		assert.Equal(&poll.AnswerOption{Answer: answerOptions[0], Voter: []string{}}, p.AnswerOptions[0])
+		assert.Equal(&poll.AnswerOption{Answer: answerOptions[1], Voter: []string{}}, p.AnswerOptions[1])
+		assert.Equal(&poll.AnswerOption{Answer: answerOptions[2], Voter: []string{}}, p.AnswerOptions[2])
 		assert.Equal(poll.Settings{Anonymous: true, Progress: true, PublicAddOption: true}, p.Settings)
 	})
 	t.Run("error, unknown setting", func(t *testing.T) {
@@ -360,6 +360,7 @@ func TestPollCopy(t *testing.T) {
 		p.Question = "Different question"
 		assert.NotEqual(p.Question, p2.Question)
 		assert.NotEqual(p, p2)
+		assert.Equal(testutils.GetPoll(), p2)
 	})
 	t.Run("change AnswerOptions", func(t *testing.T) {
 		p := testutils.GetPoll()
@@ -368,6 +369,16 @@ func TestPollCopy(t *testing.T) {
 		p.AnswerOptions[0].Answer = "abc"
 		assert.NotEqual(p.AnswerOptions[0].Answer, p2.AnswerOptions[0].Answer)
 		assert.NotEqual(p, p2)
+		assert.Equal(testutils.GetPoll(), p2)
+	})
+	t.Run("change Voter", func(t *testing.T) {
+		p := testutils.GetPollWithVotes()
+		p2 := p.Copy()
+
+		err := p.UpdateVote("userID1", 0)
+		require.Nil(t, err)
+		assert.NotEqual(p, p2)
+		assert.Equal(testutils.GetPollWithVotes(), p2)
 	})
 	t.Run("change Settings", func(t *testing.T) {
 		p := testutils.GetPoll()
@@ -376,5 +387,6 @@ func TestPollCopy(t *testing.T) {
 		p.Settings.Progress = true
 		assert.NotEqual(p.Settings.Progress, p2.Settings.Progress)
 		assert.NotEqual(p, p2)
+		assert.Equal(testutils.GetPoll(), p2)
 	})
 }

--- a/server/utils/testutils/data.go
+++ b/server/utils/testutils/data.go
@@ -42,11 +42,16 @@ func GetPoll() *poll.Poll {
 		CreatedAt: 1234567890,
 		Creator:   "userID1",
 		Question:  "Question",
-		AnswerOptions: []*poll.AnswerOption{
-			{Answer: "Answer 1"},
-			{Answer: "Answer 2"},
-			{Answer: "Answer 3"},
-		},
+		AnswerOptions: []*poll.AnswerOption{{
+			Answer: "Answer 1",
+			Voter:  []string{},
+		}, {
+			Answer: "Answer 2",
+			Voter:  []string{},
+		}, {
+			Answer: "Answer 3",
+			Voter:  []string{},
+		}},
 	}
 }
 
@@ -64,13 +69,16 @@ func GetPollWithVotes() *poll.Poll {
 		CreatedAt: 1234567890,
 		Creator:   "userID1",
 		Question:  "Question",
-		AnswerOptions: []*poll.AnswerOption{
-			{Answer: "Answer 1",
-				Voter: []string{"userID1", "userID2", "userID3"}},
-			{Answer: "Answer 2",
-				Voter: []string{"userID4"}},
-			{Answer: "Answer 3"},
-		},
+		AnswerOptions: []*poll.AnswerOption{{
+			Answer: "Answer 1",
+			Voter:  []string{"userID1", "userID2", "userID3"},
+		}, {
+			Answer: "Answer 2",
+			Voter:  []string{"userID4"},
+		}, {
+			Answer: "Answer 3",
+			Voter:  []string{},
+		}},
 	}
 }
 
@@ -88,9 +96,12 @@ func GetPollTwoOptions() *poll.Poll {
 		CreatedAt: 1234567890,
 		Creator:   "userID1",
 		Question:  "Question",
-		AnswerOptions: []*poll.AnswerOption{
-			{Answer: "Yes"},
-			{Answer: "No"},
-		},
+		AnswerOptions: []*poll.AnswerOption{{
+			Answer: "Yes",
+			Voter:  []string{},
+		}, {
+			Answer: "No",
+			Voter:  []string{},
+		}},
 	}
 }


### PR DESCRIPTION
`Poll.AnswerOption.Voter` was't correctly deep copied and therefore changes on the origin also changed the copy. This PR fixed it by correctly deep copying `Voters`.

Another carve is that `Voter` is `nil` for "new" options, but might become `[]string{}` when a user first votes for it and then votes for another option. To avoid this confusion in the future, `[]string{}` is now used for new options. Please note that polls fetched from the DB might still have a `nil` value, hence we have to still think about this case in the future.

Fixes https://github.com/matterpoll/matterpoll/issues/282