### PR TITLE
Register Command in OnActivate

### DIFF
--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -89,6 +89,10 @@ func (p *MatterpollPlugin) OnActivate() error {
 		return errors.Wrap(err, "failed to patch bot description")
 	}
 
+	if err := p.API.RegisterCommand(p.getCommand(p.getConfiguration().Trigger)); err != nil {
+		return errors.Wrap(err, "failed to register  command")
+	}
+
 	p.router = p.InitAPI()
 
 	p.setActivated(true)

--- a/server/plugin/plugin_test.go
+++ b/server/plugin/plugin_test.go
@@ -47,6 +47,13 @@ func TestPluginOnActivate(t *testing.T) {
 		DisplayName: botDisplayName,
 	}
 
+	command := &model.Command{
+		Trigger:          "poll",
+		AutoComplete:     true,
+		AutoCompleteDesc: "Create a poll",
+		AutoCompleteHint: `"[Question]" "[Answer 1]" "[Answer 2]"...`,
+	}
+
 	for name, test := range map[string]struct {
 		SetupAPI     func(*plugintest.API) *plugintest.API
 		SetupHelpers func(*plugintest.Helpers) *plugintest.Helpers
@@ -64,6 +71,7 @@ func TestPluginOnActivate(t *testing.T) {
 				require.Nil(t, err)
 				api.On("GetBundlePath").Return(path, nil)
 				api.On("PatchBot", testutils.GetBotUserID(), &model.BotPatch{Description: &botDescription.Other}).Return(nil, nil)
+				api.On("RegisterCommand", command).Return(nil)
 				return api
 			},
 			SetupHelpers: func(helpers *plugintest.Helpers) *plugintest.Helpers {
@@ -80,6 +88,7 @@ func TestPluginOnActivate(t *testing.T) {
 				require.Nil(t, err)
 				api.On("GetBundlePath").Return(path, nil)
 				api.On("PatchBot", testutils.GetBotUserID(), &model.BotPatch{Description: &botDescription.Other}).Return(nil, nil)
+				api.On("RegisterCommand", command).Return(nil)
 				return api
 			},
 			SetupHelpers: func(helpers *plugintest.Helpers) *plugintest.Helpers {


### PR DESCRIPTION
`OnConfigurationChange` might not be called after `OnActivate`. This PR ensures that the command is correctly registered by calling `RegisterCommand` in `OnActivate`.

See https://mattermost.atlassian.net/browse/MM-27174 for more details.