### PR TITLE
🌐🐛 Fix FR translation

### DIFF
--- a/assets/i18n/active.fr.json
+++ b/assets/i18n/active.fr.json
@@ -210,7 +210,7 @@
   },
   "response.vote.multi.updated": {
     "hash": "sha1-213785e569b994863b96b984772e9497f8629bbc",
-    "one": "Votre vote a été pris en compte. Vous avez encore {{.Remains}} votes.",
+    "one": "Votre vote a été pris en compte. Vous avez encore {{.Remains}} vote.",
     "other": "Votre vote a été pris en compte. Vous avez encore {{.Remains}} votes."
   },
   "response.vote.updated": {


### PR DESCRIPTION
As said in [#339](https://github.com/matterpoll/matterpoll/pull/339#issuecomment-704713346), I have been confused by the same text for "one" and "other" in `response.vote.multi.updated`.

Fixed.