### PR TITLE
Use French instead of France

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ The localization process is defined below:
 
 ### Translation Maintainers
 
-- France: [@ldidry](https://github.com/ldidry)
+- French: [@ldidry](https://github.com/ldidry)
 - German: [@hanzei](https://github.com/hanzei)
 - Japanese: [@kaakaa](https://github.com/kaakaa)
 - Korean: [@potatogim](https://github.com/potatogim)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Matterpoll supports localization of user specify messages. You can change langua
 
 The currently supported languages are:
 - English
-- France
+- French
 - German
 - Japanese
 - Korean


### PR DESCRIPTION
This PR corrects a simple typo in `README.md` and `CONTRIBUTING.md` (section Localization): `France` should be `French`.