### PR TITLE
Update CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,26 @@ orbs:
 
 workflows:
   version: 2
-  main:
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - plugin-ci/lint
+      - plugin-ci/test
+      - plugin-ci/build
+
+  ci:
     jobs:
       - plugin-ci/lint:
           filters:
             tags:
               only: /^v.*/
-      - plugin-ci/coverage:
+      - plugin-ci/test:
           filters:
             tags:
               only: /^v.*/
@@ -19,11 +32,9 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-            branches:
-              ignore: /.*/
+      - plugin-ci/coverage:
           requires:
-            - plugin-ci/lint
-            - plugin-ci/coverage
+            - plugin-ci/test
       - plugin-ci/deploy-release-github:
           filters:
             tags:
@@ -31,4 +42,6 @@ workflows:
             branches:
               ignore: /.*/
           requires:
+            - plugin-ci/lint
+            - plugin-ci/test
             - plugin-ci/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@1.0.5
-  plugin-ci: mattermost/plugin-ci@0.1.0
+  plugin-ci: mattermost/plugin-ci@0.1.6
 
 workflows:
   version: 2


### PR DESCRIPTION
- Update plugin CI orb
- Add nightly build to catch issues early
- Run `make test` before generating coverage report to ensure webapp tests pass