### PR TITLE
Drop bou.ke/moneky

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/matterpoll/matterpoll
 go 1.12
 
 require (
-	bou.ke/monkey v1.0.2
 	github.com/blang/semver/v4 v4.0.0
 	github.com/gorilla/mux v1.8.0
 	github.com/mattermost/mattermost-plugin-api v0.0.12
@@ -11,5 +10,6 @@ require (
 	github.com/nicksnyder/go-i18n/v2 v2.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
+	github.com/undefinedlabs/go-mpatch v1.0.6
 	golang.org/x/text v0.3.6
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
-bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.31.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -953,6 +951,8 @@ github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLY
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/undefinedlabs/go-mpatch v1.0.6 h1:h8q5ORH/GaOE1Se1DMhrOyljXZEhRcROO7agMqWXCOY=
+github.com/undefinedlabs/go-mpatch v1.0.6/go.mod h1:TyJZDQ/5AgyN7FSLiBJ8RO9u2c6wbtRvK827b6AVqY4=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.6.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBnvPM1Su9w=

--- a/server/plugin/api_test.go
+++ b/server/plugin/api_test.go
@@ -11,12 +11,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/undefinedlabs/go-mpatch"
 
 	"github.com/matterpoll/matterpoll/server/poll"
 	"github.com/matterpoll/matterpoll/server/store/mockstore"
@@ -529,8 +529,8 @@ func TestHandleCreatePoll(t *testing.T) {
 			defer store.AssertExpectations(t)
 			p := setupTestPlugin(t, api, store)
 
-			patch1 := monkey.Patch(model.GetMillis, func() int64 { return 1234567890 })
-			patch2 := monkey.Patch(model.NewId, testutils.GetPollID)
+			patch1, _ := mpatch.PatchMethod(model.GetMillis, func() int64 { return 1234567890 })
+			patch2, _ := mpatch.PatchMethod(model.NewId, testutils.GetPollID)
 			defer patch1.Unpatch()
 			defer patch2.Unpatch()
 

--- a/server/plugin/api_test.go
+++ b/server/plugin/api_test.go
@@ -531,8 +531,8 @@ func TestHandleCreatePoll(t *testing.T) {
 
 			patch1, _ := mpatch.PatchMethod(model.GetMillis, func() int64 { return 1234567890 })
 			patch2, _ := mpatch.PatchMethod(model.NewId, testutils.GetPollID)
-			defer patch1.Unpatch()
-			defer patch2.Unpatch()
+			defer func() { require.NoError(t, patch1.Unpatch()) }()
+			defer func() { require.NoError(t, patch2.Unpatch()) }()
 
 			w := httptest.NewRecorder()
 			url := "/api/v1/polls/create"

--- a/server/plugin/command_test.go
+++ b/server/plugin/command_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/undefinedlabs/go-mpatch"
 
 	"github.com/matterpoll/matterpoll/server/poll"
@@ -393,8 +394,8 @@ func TestPluginExecuteCommand(t *testing.T) {
 
 			patch1, _ := mpatch.PatchMethod(model.GetMillis, func() int64 { return 1234567890 })
 			patch2, _ := mpatch.PatchMethod(model.NewId, testutils.GetPollID)
-			defer patch1.Unpatch()
-			defer patch2.Unpatch()
+			defer func() { require.NoError(t, patch1.Unpatch()) }()
+			defer func() { require.NoError(t, patch2.Unpatch()) }()
 
 			r, err := p.ExecuteCommand(nil, &model.CommandArgs{
 				Command:   test.Command,

--- a/server/plugin/command_test.go
+++ b/server/plugin/command_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
 	"github.com/stretchr/testify/assert"
+	"github.com/undefinedlabs/go-mpatch"
 
 	"github.com/matterpoll/matterpoll/server/poll"
 	"github.com/matterpoll/matterpoll/server/store/mockstore"
@@ -391,8 +391,8 @@ func TestPluginExecuteCommand(t *testing.T) {
 			p := setupTestPlugin(t, api, store)
 			p.configuration.Trigger = trigger
 
-			patch1 := monkey.Patch(model.GetMillis, func() int64 { return 1234567890 })
-			patch2 := monkey.Patch(model.NewId, testutils.GetPollID)
+			patch1, _ := mpatch.PatchMethod(model.GetMillis, func() int64 { return 1234567890 })
+			patch2, _ := mpatch.PatchMethod(model.NewId, testutils.GetPollID)
 			defer patch1.Unpatch()
 			defer patch2.Unpatch()
 

--- a/server/plugin/plugin_test.go
+++ b/server/plugin/plugin_test.go
@@ -137,7 +137,7 @@ func TestPluginOnActivate(t *testing.T) {
 			patch, _ := mpatch.PatchMethod(kvstore.NewStore, func(plugin.API, string) (store.Store, error) {
 				return &mockstore.Store{}, nil
 			})
-			defer patch.Unpatch()
+			defer func() { require.NoError(t, patch.Unpatch()) }()
 
 			siteURL := testutils.GetSiteURL()
 			defaultClientLocale := "en"
@@ -173,7 +173,7 @@ func TestPluginOnActivate(t *testing.T) {
 		patch, _ := mpatch.PatchMethod(kvstore.NewStore, func(plugin.API, string) (store.Store, error) {
 			return nil, &model.AppError{}
 		})
-		defer patch.Unpatch()
+		defer func() { require.NoError(t, patch.Unpatch()) }()
 
 		siteURL := testutils.GetSiteURL()
 		p := &MatterpollPlugin{
@@ -198,7 +198,7 @@ func TestPluginOnActivate(t *testing.T) {
 		patch, _ := mpatch.PatchMethod(kvstore.NewStore, func(plugin.API, string) (store.Store, error) {
 			return nil, &model.AppError{}
 		})
-		defer patch.Unpatch()
+		defer func() { require.NoError(t, patch.Unpatch()) }()
 
 		p := &MatterpollPlugin{
 			ServerConfig: &model.Config{

--- a/server/plugin/plugin_test.go
+++ b/server/plugin/plugin_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin"
 	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
@@ -13,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/undefinedlabs/go-mpatch"
 	"golang.org/x/text/language"
 
 	"github.com/matterpoll/matterpoll/server/store"
@@ -134,7 +134,7 @@ func TestPluginOnActivate(t *testing.T) {
 				defer helpers.AssertExpectations(t)
 			}
 
-			patch := monkey.Patch(kvstore.NewStore, func(plugin.API, string) (store.Store, error) {
+			patch, _ := mpatch.PatchMethod(kvstore.NewStore, func(plugin.API, string) (store.Store, error) {
 				return &mockstore.Store{}, nil
 			})
 			defer patch.Unpatch()
@@ -170,7 +170,7 @@ func TestPluginOnActivate(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
 
-		patch := monkey.Patch(kvstore.NewStore, func(plugin.API, string) (store.Store, error) {
+		patch, _ := mpatch.PatchMethod(kvstore.NewStore, func(plugin.API, string) (store.Store, error) {
 			return nil, &model.AppError{}
 		})
 		defer patch.Unpatch()
@@ -195,7 +195,7 @@ func TestPluginOnActivate(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
 
-		patch := monkey.Patch(kvstore.NewStore, func(plugin.API, string) (store.Store, error) {
+		patch, _ := mpatch.PatchMethod(kvstore.NewStore, func(plugin.API, string) (store.Store, error) {
 			return nil, &model.AppError{}
 		})
 		defer patch.Unpatch()

--- a/server/poll/poll_test.go
+++ b/server/poll/poll_test.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	mpatch "github.com/undefinedlabs/go-mpatch"
 
 	"github.com/matterpoll/matterpoll/server/poll"
 	"github.com/matterpoll/matterpoll/server/utils/testutils"
@@ -16,8 +16,8 @@ import (
 func TestNewPoll(t *testing.T) {
 	t.Run("all fine", func(t *testing.T) {
 		assert := assert.New(t)
-		patch1 := monkey.Patch(model.GetMillis, func() int64 { return 1234567890 })
-		patch2 := monkey.Patch(model.NewId, testutils.GetPollID)
+		patch1, _ := mpatch.PatchMethod(model.GetMillis, func() int64 { return 1234567890 })
+		patch2, _ := mpatch.PatchMethod(model.NewId, testutils.GetPollID)
 		defer patch1.Unpatch()
 		defer patch2.Unpatch()
 
@@ -45,8 +45,8 @@ func TestNewPoll(t *testing.T) {
 
 	t.Run("error, invalid votes setting", func(t *testing.T) {
 		assert := assert.New(t)
-		patch1 := monkey.Patch(model.GetMillis, func() int64 { return 1234567890 })
-		patch2 := monkey.Patch(model.NewId, testutils.GetPollID)
+		patch1, _ := mpatch.PatchMethod(model.GetMillis, func() int64 { return 1234567890 })
+		patch2, _ := mpatch.PatchMethod(model.NewId, testutils.GetPollID)
 		defer patch1.Unpatch()
 		defer patch2.Unpatch()
 

--- a/server/poll/poll_test.go
+++ b/server/poll/poll_test.go
@@ -18,8 +18,8 @@ func TestNewPoll(t *testing.T) {
 		assert := assert.New(t)
 		patch1, _ := mpatch.PatchMethod(model.GetMillis, func() int64 { return 1234567890 })
 		patch2, _ := mpatch.PatchMethod(model.NewId, testutils.GetPollID)
-		defer patch1.Unpatch()
-		defer patch2.Unpatch()
+		defer func() { require.NoError(t, patch1.Unpatch()) }()
+		defer func() { require.NoError(t, patch2.Unpatch()) }()
 
 		creator := model.NewRandomString(10)
 		question := model.NewRandomString(10)
@@ -47,8 +47,8 @@ func TestNewPoll(t *testing.T) {
 		assert := assert.New(t)
 		patch1, _ := mpatch.PatchMethod(model.GetMillis, func() int64 { return 1234567890 })
 		patch2, _ := mpatch.PatchMethod(model.NewId, testutils.GetPollID)
-		defer patch1.Unpatch()
-		defer patch2.Unpatch()
+		defer func() { require.NoError(t, patch1.Unpatch()) }()
+		defer func() { require.NoError(t, patch2.Unpatch()) }()
 
 		creator := model.NewRandomString(10)
 		question := model.NewRandomString(10)


### PR DESCRIPTION
Since [bou.ke/monkey's license](https://github.com/bouk/monkey/blob/master/LICENSE.md) says that `I do not give anyone permissions to use this tool for any purpose.`, drop `bou.ke/monkey` and use [`undefinedlabs/go-mpatch`](https://github.com/undefinedlabs/go-mpatch) (released under MIT license) instead.

`undefinedlabs/go-mpatch` seems to be used by [Argo](https://github.com/argoproj/argo-cd/blob/master/go.mod#L67) which is the CNCF incubating project.