### PR TITLE
Poll options to allow anyone to delete or end a poll

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -577,12 +577,14 @@ func (p *MatterpollPlugin) handleEndPoll(vars map[string]string, request *model.
 		return &i18n.LocalizeConfig{DefaultMessage: commandErrorGeneric}, nil, errors.Wrap(err, "failed to get poll")
 	}
 
-	canManagePoll, appErr := p.CanManagePoll(poll, request.UserId)
-	if appErr != nil {
-		return &i18n.LocalizeConfig{DefaultMessage: commandErrorGeneric}, nil, errors.Wrap(appErr, "failed to check permission")
-	}
-	if !canManagePoll {
-		return &i18n.LocalizeConfig{DefaultMessage: responseEndPollInvalidPermission}, nil, nil
+	if !poll.Settings.PublicEndPoll {
+		canManagePoll, appErr := p.CanManagePoll(poll, request.UserId)
+		if appErr != nil {
+			return &i18n.LocalizeConfig{DefaultMessage: commandErrorGeneric}, nil, errors.Wrap(appErr, "failed to check permission")
+		}
+		if !canManagePoll {
+			return &i18n.LocalizeConfig{DefaultMessage: responseEndPollInvalidPermission}, nil, nil
+		}
 	}
 
 	siteURL := *p.ServerConfig.ServiceSettings.SiteURL
@@ -677,12 +679,14 @@ func (p *MatterpollPlugin) handleDeletePoll(vars map[string]string, request *mod
 		return &i18n.LocalizeConfig{DefaultMessage: commandErrorGeneric}, nil, errors.Wrap(err, "failed to get poll")
 	}
 
-	canManagePoll, appErr := p.CanManagePoll(poll, request.UserId)
-	if appErr != nil {
-		return &i18n.LocalizeConfig{DefaultMessage: commandErrorGeneric}, nil, errors.Wrap(appErr, "failed to check permission")
-	}
-	if !canManagePoll {
-		return &i18n.LocalizeConfig{DefaultMessage: responseDeletePollInvalidPermission}, nil, nil
+	if !poll.Settings.PublicDeletePoll {
+		canManagePoll, appErr := p.CanManagePoll(poll, request.UserId)
+		if appErr != nil {
+			return &i18n.LocalizeConfig{DefaultMessage: commandErrorGeneric}, nil, errors.Wrap(appErr, "failed to check permission")
+		}
+		if !canManagePoll {
+			return &i18n.LocalizeConfig{DefaultMessage: responseDeletePollInvalidPermission}, nil, nil
+		}
 	}
 
 	siteURL := *p.ServerConfig.ServiceSettings.SiteURL

--- a/server/plugin/api_test.go
+++ b/server/plugin/api_test.go
@@ -655,11 +655,13 @@ func TestHandleVote(t *testing.T) {
 				api.On("HasPermissionToChannel", "userID1", "channelID1", model.PERMISSION_READ_CHANNEL).Return(true)
 				api.On("GetUser", "userID1").Return(&model.User{FirstName: "John", LastName: "Doe"}, nil)
 				api.On("PublishWebSocketEvent", "has_voted", map[string]interface{}{
-					"voted_answers":             []string{"Answer 1"},
-					"poll_id":                   testutils.GetPollID(),
-					"user_id":                   "userID1",
-					"can_manage_poll":           true,
-					"setting_public_add_option": false,
+					"voted_answers":              []string{"Answer 1"},
+					"poll_id":                    testutils.GetPollID(),
+					"user_id":                    "userID1",
+					"can_manage_poll":            true,
+					"setting_public_add_option":  false,
+					"setting_public_delete_poll": false,
+					"setting_public_end_poll":    false,
 				}, &model.WebsocketBroadcast{UserId: "userID1"}).Return()
 				return api
 			},
@@ -679,11 +681,13 @@ func TestHandleVote(t *testing.T) {
 				api.On("HasPermissionToChannel", "userID1", "channelID1", model.PERMISSION_READ_CHANNEL).Return(true)
 				api.On("GetUser", "userID1").Return(&model.User{FirstName: "John", LastName: "Doe"}, nil)
 				api.On("PublishWebSocketEvent", "has_voted", map[string]interface{}{
-					"voted_answers":             []string{"Answer 1"},
-					"poll_id":                   testutils.GetPollID(),
-					"user_id":                   "userID1",
-					"can_manage_poll":           true,
-					"setting_public_add_option": false,
+					"voted_answers":              []string{"Answer 1"},
+					"poll_id":                    testutils.GetPollID(),
+					"user_id":                    "userID1",
+					"can_manage_poll":            true,
+					"setting_public_add_option":  false,
+					"setting_public_delete_poll": false,
+					"setting_public_end_poll":    false,
 				}, &model.WebsocketBroadcast{UserId: "userID1"}).Return()
 				return api
 			},
@@ -709,11 +713,13 @@ func TestHandleVote(t *testing.T) {
 				api.On("GetUser", "userID1").Return(&model.User{FirstName: "John", LastName: "Doe"}, nil)
 				api.On("GetUser", "userID2").Return(&model.User{FirstName: "John", LastName: "Doe"}, nil)
 				api.On("PublishWebSocketEvent", "has_voted", map[string]interface{}{
-					"can_manage_poll":           false,
-					"poll_id":                   testutils.GetPollID(),
-					"user_id":                   "userID2",
-					"voted_answers":             []string{"Answer 1"},
-					"setting_public_add_option": false,
+					"can_manage_poll":            false,
+					"poll_id":                    testutils.GetPollID(),
+					"user_id":                    "userID2",
+					"voted_answers":              []string{"Answer 1"},
+					"setting_public_add_option":  false,
+					"setting_public_delete_poll": false,
+					"setting_public_end_poll":    false,
 				}, &model.WebsocketBroadcast{UserId: "userID2"}).Return()
 				return api
 			},
@@ -734,11 +740,13 @@ func TestHandleVote(t *testing.T) {
 				api.On("HasPermissionToChannel", "userID1", "channelID1", model.PERMISSION_READ_CHANNEL).Return(true)
 				api.On("GetUser", "userID1").Return(&model.User{FirstName: "John", LastName: "Doe"}, nil)
 				api.On("PublishWebSocketEvent", "has_voted", map[string]interface{}{
-					"can_manage_poll":           true,
-					"poll_id":                   testutils.GetPollID(),
-					"user_id":                   "userID1",
-					"voted_answers":             []string{"Answer 1", "Answer 2"},
-					"setting_public_add_option": false,
+					"can_manage_poll":            true,
+					"poll_id":                    testutils.GetPollID(),
+					"user_id":                    "userID1",
+					"voted_answers":              []string{"Answer 1", "Answer 2"},
+					"setting_public_add_option":  false,
+					"setting_public_delete_poll": false,
+					"setting_public_end_poll":    false,
 				}, &model.WebsocketBroadcast{UserId: "userID1"}).Return()
 				return api
 			},
@@ -776,11 +784,13 @@ func TestHandleVote(t *testing.T) {
 				api.On("HasPermissionToChannel", "userID1", "channelID1", model.PERMISSION_READ_CHANNEL).Return(true)
 				api.On("GetUser", "userID1").Return(&model.User{FirstName: "John", LastName: "Doe"}, nil)
 				api.On("PublishWebSocketEvent", "has_voted", map[string]interface{}{
-					"voted_answers":             []string{"Answer 2"},
-					"poll_id":                   testutils.GetPollID(),
-					"user_id":                   "userID1",
-					"can_manage_poll":           true,
-					"setting_public_add_option": false,
+					"voted_answers":              []string{"Answer 2"},
+					"poll_id":                    testutils.GetPollID(),
+					"user_id":                    "userID1",
+					"can_manage_poll":            true,
+					"setting_public_add_option":  false,
+					"setting_public_delete_poll": false,
+					"setting_public_end_poll":    false,
 				}, &model.WebsocketBroadcast{UserId: "userID1"}).Return()
 				return api
 			},
@@ -827,11 +837,13 @@ func TestHandleVote(t *testing.T) {
 				api.On("GetUser", "userID2").Return(nil, &model.AppError{})
 				api.On("LogWarn", testutils.GetMockArgumentsWithType("string", 7)...).Return().Maybe()
 				api.On("PublishWebSocketEvent", "has_voted", map[string]interface{}{
-					"voted_answers":             []string{"Answer 2"},
-					"poll_id":                   testutils.GetPollID(),
-					"user_id":                   "userID2",
-					"can_manage_poll":           false,
-					"setting_public_add_option": false,
+					"voted_answers":              []string{"Answer 2"},
+					"poll_id":                    testutils.GetPollID(),
+					"user_id":                    "userID2",
+					"can_manage_poll":            false,
+					"setting_public_add_option":  false,
+					"setting_public_delete_poll": false,
+					"setting_public_end_poll":    false,
 				}, &model.WebsocketBroadcast{UserId: "userID2"}).Return()
 				return api
 			},
@@ -1078,11 +1090,13 @@ func TestHandleResetVotes(t *testing.T) {
 				api.On("HasPermissionToChannel", "userID1", "channelID1", model.PERMISSION_READ_CHANNEL).Return(true)
 				api.On("GetUser", "userID1").Return(&model.User{FirstName: "John", LastName: "Doe"}, nil)
 				api.On("PublishWebSocketEvent", "has_voted", map[string]interface{}{
-					"can_manage_poll":           true,
-					"poll_id":                   testutils.GetPollID(),
-					"user_id":                   "userID1",
-					"voted_answers":             []string{},
-					"setting_public_add_option": false,
+					"can_manage_poll":            true,
+					"poll_id":                    testutils.GetPollID(),
+					"user_id":                    "userID1",
+					"voted_answers":              []string{},
+					"setting_public_add_option":  false,
+					"setting_public_delete_poll": false,
+					"setting_public_end_poll":    false,
 				}, &model.WebsocketBroadcast{UserId: "userID1"}).Return()
 				return api
 			},
@@ -1101,11 +1115,13 @@ func TestHandleResetVotes(t *testing.T) {
 				api.On("HasPermissionToChannel", "userID1", "channelID1", model.PERMISSION_READ_CHANNEL).Return(true)
 				api.On("GetUser", "userID1").Return(&model.User{FirstName: "John", LastName: "Doe"}, nil)
 				api.On("PublishWebSocketEvent", "has_voted", map[string]interface{}{
-					"can_manage_poll":           true,
-					"poll_id":                   testutils.GetPollID(),
-					"user_id":                   "userID1",
-					"voted_answers":             []string{},
-					"setting_public_add_option": false,
+					"can_manage_poll":            true,
+					"poll_id":                    testutils.GetPollID(),
+					"user_id":                    "userID1",
+					"voted_answers":              []string{},
+					"setting_public_add_option":  false,
+					"setting_public_delete_poll": false,
+					"setting_public_end_poll":    false,
 				}, &model.WebsocketBroadcast{UserId: "userID1"}).Return()
 				return api
 			},

--- a/server/plugin/api_test.go
+++ b/server/plugin/api_test.go
@@ -216,7 +216,7 @@ func TestHandleCreatePoll(t *testing.T) {
 	}
 	model.ParseSlackAttachment(expectedPostTwoOptions, pollWithTwoOptions.ToPostActions(testutils.GetBundle(), manifest.Id, "John Doe"))
 
-	pollWithSettings := testutils.GetPollWithSettings(poll.Settings{Progress: true, Anonymous: true, PublicAddOption: true, MaxVotes: 3})
+	pollWithSettings := testutils.GetPollWithSettings(poll.Settings{Progress: true, Anonymous: true, PublicAddOption: true, PublicDeletePoll: true, PublicEndPoll: true, MaxVotes: 3})
 	expectedPostWithSettings := &model.Post{
 		UserId:    testutils.GetBotUserID(),
 		ChannelId: channelID,
@@ -315,14 +315,16 @@ func TestHandleCreatePoll(t *testing.T) {
 				CallbackId: rootID,
 				ChannelId:  channelID,
 				Submission: map[string]interface{}{
-					"question":                  pollWithSettings.Question,
-					"option1":                   pollWithSettings.AnswerOptions[0].Answer,
-					"option2":                   pollWithSettings.AnswerOptions[1].Answer,
-					"option3":                   pollWithSettings.AnswerOptions[2].Answer,
-					"setting-multi":             3,
-					"setting-anonymous":         true,
-					"setting-progress":          true,
-					"setting-public-add-option": true,
+					"question":                   pollWithSettings.Question,
+					"option1":                    pollWithSettings.AnswerOptions[0].Answer,
+					"option2":                    pollWithSettings.AnswerOptions[1].Answer,
+					"option3":                    pollWithSettings.AnswerOptions[2].Answer,
+					"setting-multi":              3,
+					"setting-anonymous":          true,
+					"setting-progress":           true,
+					"setting-public-add-option":  true,
+					"setting-public-delete-poll": true,
+					"setting-public-end-poll":    true,
 				},
 			},
 			ExpectedStatusCode: http.StatusOK,

--- a/server/poll/metadata.go
+++ b/server/poll/metadata.go
@@ -2,20 +2,24 @@ package poll
 
 // Metadata stores personalized metadata of a poll.
 type Metadata struct {
-	VotedAnswers           []string `json:"voted_answers"` // VotedAnswers is list of answer that the user with "UserID" have voted for the poll with "PollID"
-	PollID                 string   `json:"poll_id"`
-	UserID                 string   `json:"user_id"`
-	CanManagePoll          bool     `json:"can_manage_poll"` // CanManagePoll will be true if the user with "UserID" can manage the poll with "PollID", otherwise false.
-	SettingPublicAddOption bool     `json:"setting_public_add_option"`
+	VotedAnswers            []string `json:"voted_answers"` // VotedAnswers is list of answer that the user with "UserID" have voted for the poll with "PollID"
+	PollID                  string   `json:"poll_id"`
+	UserID                  string   `json:"user_id"`
+	CanManagePoll           bool     `json:"can_manage_poll"` // CanManagePoll will be true if the user with "UserID" can manage the poll with "PollID", otherwise false.
+	SettingPublicAddOption  bool     `json:"setting_public_add_option"`
+	SettingPublicDeletePoll bool     `json:"setting_public_delete_poll"`
+	SettingPublicEndPoll    bool     `json:"setting_public_end_poll"`
 }
 
 // ToMap returns a Metadata as a map
 func (m *Metadata) ToMap() map[string]interface{} {
 	return map[string]interface{}{
-		"voted_answers":             m.VotedAnswers,
-		"poll_id":                   m.PollID,
-		"user_id":                   m.UserID,
-		"can_manage_poll":           m.CanManagePoll,
-		"setting_public_add_option": m.SettingPublicAddOption,
+		"voted_answers":              m.VotedAnswers,
+		"poll_id":                    m.PollID,
+		"user_id":                    m.UserID,
+		"can_manage_poll":            m.CanManagePoll,
+		"setting_public_add_option":  m.SettingPublicAddOption,
+		"setting_public_delete_poll": m.SettingPublicDeletePoll,
+		"setting_public_end_poll":    m.SettingPublicEndPoll,
 	}
 }

--- a/server/poll/metadata_test.go
+++ b/server/poll/metadata_test.go
@@ -10,18 +10,22 @@ import (
 
 func TestToMap(t *testing.T) {
 	m := poll.Metadata{
-		PollID:                 "pollID",
-		UserID:                 "userID",
-		CanManagePoll:          true,
-		SettingPublicAddOption: true,
+		PollID:                  "pollID",
+		UserID:                  "userID",
+		CanManagePoll:           true,
+		SettingPublicAddOption:  true,
+		SettingPublicDeletePoll: true,
+		SettingPublicEndPoll:    true,
 	}
 
 	expectedMap := map[string]interface{}{
-		"voted_answers":             []string(nil),
-		"poll_id":                   "pollID",
-		"user_id":                   "userID",
-		"can_manage_poll":           true,
-		"setting_public_add_option": true,
+		"voted_answers":              []string(nil),
+		"poll_id":                    "pollID",
+		"user_id":                    "userID",
+		"can_manage_poll":            true,
+		"setting_public_add_option":  true,
+		"setting_public_delete_poll": true,
+		"setting_public_end_poll":    true,
 	}
 	assert.Equal(t, expectedMap, m.ToMap())
 }

--- a/server/poll/poll.go
+++ b/server/poll/poll.go
@@ -16,9 +16,11 @@ import (
 var votesSettingPattern = regexp.MustCompile(`^votes=(\d+)$`)
 
 const (
-	SettingKeyAnonymous       = "anonymous"
-	SettingKeyProgress        = "progress"
-	SettingKeyPublicAddOption = "public-add-option"
+	SettingKeyAnonymous        = "anonymous"
+	SettingKeyProgress         = "progress"
+	SettingKeyPublicAddOption  = "public-add-option"
+	SettingKeyPublicDeletePoll = "public-delete-poll"
+	SettingKeyPublicEndPoll    = "public-end-poll"
 )
 
 // Poll stores all needed information for a poll
@@ -40,10 +42,12 @@ type AnswerOption struct {
 
 // Settings stores possible settings for a poll
 type Settings struct {
-	Anonymous       bool
-	Progress        bool
-	PublicAddOption bool
-	MaxVotes        int `json:"max_votes"`
+	Anonymous        bool
+	Progress         bool
+	PublicAddOption  bool
+	PublicDeletePoll bool
+	PublicEndPoll    bool
+	MaxVotes         int `json:"max_votes"`
 }
 
 // NewPoll creates a new poll with the given parameter.
@@ -79,6 +83,10 @@ func NewSettingsFromStrings(strs []string) (Settings, *utils.ErrorMessage) {
 			settings.Progress = true
 		case str == SettingKeyPublicAddOption:
 			settings.PublicAddOption = true
+		case str == SettingKeyPublicDeletePoll:
+			settings.PublicDeletePoll = true
+		case str == SettingKeyPublicEndPoll:
+			settings.PublicEndPoll = true
 		case votesSettingPattern.MatchString(str):
 			i, errMsg := parseVotesSettings(str)
 			if errMsg != nil {
@@ -120,6 +128,10 @@ func NewSettingsFromSubmission(submission map[string]interface{}) Settings {
 					settings.Progress = true
 				case SettingKeyPublicAddOption:
 					settings.PublicAddOption = true
+				case SettingKeyPublicDeletePoll:
+					settings.PublicDeletePoll = true
+				case SettingKeyPublicEndPoll:
+					settings.PublicEndPoll = true
 				}
 			}
 		}
@@ -295,11 +307,13 @@ func (p *Poll) GetMetadata(userID string, permission bool) *Metadata {
 		}
 	}
 	return &Metadata{
-		PollID:                 p.ID,
-		UserID:                 userID,
-		CanManagePoll:          permission,
-		VotedAnswers:           votedAnswers,
-		SettingPublicAddOption: p.Settings.PublicAddOption,
+		PollID:                  p.ID,
+		UserID:                  userID,
+		CanManagePoll:           permission,
+		VotedAnswers:            votedAnswers,
+		SettingPublicAddOption:  p.Settings.PublicAddOption,
+		SettingPublicDeletePoll: p.Settings.PublicDeletePoll,
+		SettingPublicEndPoll:    p.Settings.PublicEndPoll,
 	}
 }
 

--- a/server/poll/transform.go
+++ b/server/poll/transform.go
@@ -136,6 +136,12 @@ func (p *Poll) makeAdditionalText(bundle *utils.Bundle, numberOfVotes int) strin
 	if p.Settings.PublicAddOption {
 		settingsText = append(settingsText, "public-add-option")
 	}
+	if p.Settings.PublicDeletePoll {
+		settingsText = append(settingsText, "public-delete-poll")
+	}
+	if p.Settings.PublicEndPoll {
+		settingsText = append(settingsText, "public-end-poll")
+	}
 	if p.Settings.MaxVotes > 1 {
 		settingsText = append(settingsText, fmt.Sprintf("votes=%d", p.Settings.MaxVotes))
 	}


### PR DESCRIPTION
Hi,

We have created a Mattermost integration in which users invoke actions and responses from a bot account via a slash command. One such action we would like to include is the ability for the bot account to assemble and post polls. In other words, the custom slash command becomes shorthand for creating what otherwise would be very verbose poll commands.

The issue is that we use the bot account personal access token to interact with the Mattermost server. In the case of polls, we are using the bot token to execute the poll command. This works fine, however, because the bot account is the one ultimately creating the poll, no one outside of admins are able to delete or end it due to the permission checks guarding those actions.

We'd like to find a way around this permission issue to allow the bot account to create the poll, but a non-admin user to delete or end it. It turns out, in this narrow use case, we are actually fine with anyone deleting or ending the poll and so this PR introduces two new poll command options: `--public-delete-poll` and `--public-end-poll`. Both follow the exact same pattern laid out by the `--public-add-option` flag.

Thanks for the consideration. Please let me know if there's anything that I can/should update.
-Tim Kral