### PR TITLE
Fix ci error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,8 @@ workflows:
       - plugin-ci/coverage:
           requires:
             - plugin-ci/test
+          pre-steps:
+            - use_https
       - plugin-ci/deploy-release-github:
           filters:
             tags:
@@ -63,3 +65,5 @@ workflows:
             - plugin-ci/lint
             - plugin-ci/test
             - plugin-ci/build
+          pre-steps:
+            - use_https

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,12 @@ version: 2.1
 orbs:
   plugin-ci: mattermost/plugin-ci@0.1.6
 
+commands:
+  use_https:
+    description: "Avoid to use git protocol to fetch dependencies from GitHub. ref: https://github.com/npm/cli/issues/4896"
+    steps:
+      - run: git config --global url."https://git@".insteadOf git://
+
 workflows:
   version: 2
   nightly:
@@ -14,9 +20,15 @@ workflows:
               only:
                 - master
     jobs:
-      - plugin-ci/lint
-      - plugin-ci/test
-      - plugin-ci/build
+      - plugin-ci/lint:
+          pre-steps:
+            - use_https
+      - plugin-ci/test:
+          pre-steps:
+            - use_https
+      - plugin-ci/build:
+          pre-steps:
+            - use_https
 
   ci:
     jobs:
@@ -24,14 +36,20 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+          pre-steps:
+            - use_https
       - plugin-ci/test:
           filters:
             tags:
               only: /^v.*/
+          pre-steps:
+            - use_https
       - plugin-ci/build:
           filters:
             tags:
               only: /^v.*/
+          pre-steps:
+            - use_https
       - plugin-ci/coverage:
           requires:
             - plugin-ci/test


### PR DESCRIPTION
Since 2 weeks ago, CI always fails.
```
#!/bin/bash -eo pipefail
make test
cd webapp && /usr/local/bin/npm install
make: *** [Makefile:81: webapp/node_modules] Terminated

Too long with no output (exceeded 10m0s): context deadline exceeded
```

This would be introduced by GitHub diabling cloning repo via git protocol. refs: https://github.com/npm/cli/issues/4896

This PR fixes the CI issue by forcing to always use https protocol when resolving npm dependencies.

---

* This PR fix CI builds on CircleCI, but fresh build on local machine with npm v6 still be very slow (about 10 and more mins on my machine)
* This changes will be removed after upgrading npm on CI environment to v7
* FYI: Changing npm dependencies from `github:mattermost/...` to `https://github.com/mattermost/...` in [`package.json`](https://github.com/matterpoll/matterpoll/blob/master/webapp/package.json) didn't solve this issue, because, probably, transitive dependencies from mattermost-webapp ([such as  marked, react-bootstrap](https://github.com/mattermost/mattermost-webapp/blob/master/package.json#L12)) still use git protocol.