### PR TITLE
Don't show user's full name when PrivacySettings.ShowFullName is disabled

### DIFF
--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -163,8 +163,8 @@ func (p *MatterpollPlugin) ConvertCreatorIDToDisplayName(creatorID string) (stri
 		return "", err
 	}
 	setting := p.ServerConfig.PrivacySettings.ShowFullName
-	// Need to check if settings value if nil pointer, because PrivacySettings.ShowFullName
-	// can be nil pointe when ShowFullName setting is false.
+	// Need to check if settings value is nil pointer, because PrivacySettings.ShowFullName
+	// can be nil pointer when ShowFullName setting is false.
 	if setting == nil || !*setting {
 		return user.GetDisplayName(model.SHOW_USERNAME), nil
 	}

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -162,8 +162,13 @@ func (p *MatterpollPlugin) ConvertCreatorIDToDisplayName(creatorID string) (stri
 	if err != nil {
 		return "", err
 	}
-	displayName := user.GetDisplayName(model.SHOW_NICKNAME_FULLNAME)
-	return displayName, nil
+	setting := p.ServerConfig.PrivacySettings.ShowFullName
+	// Need to check if settings value if nil pointer, because PrivacySettings.ShowFullName
+	// can be nil pointe when ShowFullName setting is false.
+	if setting == nil || !*setting {
+		return user.GetDisplayName(model.SHOW_USERNAME), nil
+	}
+	return user.GetDisplayName(model.SHOW_NICKNAME_FULLNAME), nil
 }
 
 // CanManagePoll checks if a given user has the permission to manage i.e. end or delete a given poll

--- a/server/utils/testutils/data.go
+++ b/server/utils/testutils/data.go
@@ -27,6 +27,7 @@ func GetServerConfig() *model.Config {
 	localeEn := "en"
 	defaultServerLocale := localeEn
 	defaultClientLocale := localeEn
+	showFullName := true
 	return &model.Config{
 		ServiceSettings: model.ServiceSettings{
 			SiteURL: &siteURL,
@@ -34,6 +35,9 @@ func GetServerConfig() *model.Config {
 		LocalizationSettings: model.LocalizationSettings{
 			DefaultServerLocale: &defaultServerLocale,
 			DefaultClientLocale: &defaultClientLocale,
+		},
+		PrivacySettings: model.PrivacySettings{
+			ShowFullName: &showFullName,
 		},
 	}
 }


### PR DESCRIPTION
fixes #440

Note: Fullname in existing polls that is already shown will be changed when any update (vote, add option, reset votes) is made to the poll.