### PR TITLE
Use version of React DOM provided by web app

### DIFF
--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -81,6 +81,7 @@ module.exports = {
     },
     externals: {
         react: 'React',
+        'react-dom': 'ReactDOM',
         redux: 'Redux',
         'react-redux': 'ReactRedux',
         'prop-types': 'PropTypes',


### PR DESCRIPTION
I tested this with ExperimentalUI setting on Mattermost v6.3.10, and it works fine.

<img width="866" alt="スクリーンショット 2022-09-22 22 54 58" src="https://user-images.githubusercontent.com/1453749/191766270-b08ab79d-6307-4df3-928f-106d0d19b721.png">

refs:
* https://github.com/mattermost/mattermost-plugin-starter-template/pull/169
* https://mattermost.atlassian.net/browse/MM-47046

TODO:
- ~~[ ] It might be needed to add other packages [refs](https://github.com/mattermost/mattermost-plugin-starter-template/pull/169#issuecomment-1250414723)~~
  - This should be fixed by another PR if needed