### PR TITLE
Add linter(forbidigo) to prevent from using MustLocalize

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,9 @@ run:
   modules-download-mode: readonly
 
 linters-settings:
+  forbidigo:
+    forbid:
+      - '^.*\.MustLocalize.*(# MustLocalize may cause panic such as #252, use one of localize functions in utils package instead)?'
   goconst:
     min-len: 2
     min-occurrences: 2
@@ -24,6 +27,7 @@ linters:
     - bodyclose
     - dogsled
     - errcheck
+    - forbidigo
     - goconst
     - gocritic
     - gofmt


### PR DESCRIPTION
fixes #433 

When detecting `MustLocalize` in code, forbidigo show the following warning.

```
$ make check-style
...
Running golangci-lint
golangci-lint run ./...
server/hoge.go:7:3: use of `loc.MustLocalize` forbidden because "MustLocalize may cause panic such as #252, use one of localize functions in utils package instead" (forbidigo)
                loc.MustLocalize(nil)
                ^
make: *** [check-style] Error 1
```