### PR TITLE
Update `marked` version

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -11936,8 +11936,8 @@
       "dev": true
     },
     "marked": {
-      "version": "github:mattermost/marked#3a9d0a5bd6d735df1a716ab50f73d58a1d865bdb",
-      "from": "github:mattermost/marked#3a9d0a5bd6d735df1a716ab50f73d58a1d865bdb"
+      "version": "github:mattermost/marked#2ef7f28cc7718e3f551c4ce9ea75fdd7580c2008",
+      "from": "github:mattermost/marked#2ef7f28cc7718e3f551c4ce9ea75fdd7580c2008"
     },
     "material-colors": {
       "version": "1.2.6",
@@ -12122,6 +12122,11 @@
           "version": "3.4.1",
           "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
           "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
+          "dev": true
+        },
+        "marked": {
+          "version": "github:mattermost/marked#3a9d0a5bd6d735df1a716ab50f73d58a1d865bdb",
+          "from": "github:mattermost/marked#3a9d0a5bd6d735df1a716ab50f73d58a1d865bdb",
           "dev": true
         },
         "mattermost-redux": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "core-js": "3.6.5",
     "invert-color": "2.0.0",
-    "marked": "github:mattermost/marked#3a9d0a5bd6d735df1a716ab50f73d58a1d865bdb",
+    "marked": "github:mattermost/marked#2ef7f28cc7718e3f551c4ce9ea75fdd7580c2008",
     "mattermost-redux": "5.33.1",
     "react": "16.13.1",
     "react-redux": "7.2.1",


### PR DESCRIPTION
fixes #469 

The following error log of #469 said that `marked` cannot handle inline latex correctly.

```
Uncaught (in promise) TypeError: this.renderer.inlinelatex is not a function
    at u.renderTokens (marked.js:887:30)
    at u.output (marked.js:852:15)
    at i.tok (marked.js:1289:50)
    at i.parse (marked.js:1146:17)
    at i.parse (marked.js:1133:17)
    at f (marked.js:1495:19)
    at h (index.ts:36:12)
    at d (text_formatting.tsx:237:18)
    at o.value (com.github.matterpoll.matterpoll_eda8fdcb9a124401_bundle.js:319:287466)
    at Ho (react-dom.production.min.js:187:188)
```

The cause of #469 is that the version of `marked` that Matterpoll depends on is old and doesn't support inline latex. So updating `marked` version fixes #469.
<img width="1013" alt="スクリーンショット 2023-01-22 15 03 01" src="https://user-images.githubusercontent.com/1453749/213902960-47700ae7-4b37-431d-913c-5bb80ce75196.png">
