### PR TITLE
fix: inconsistent capitalization in "Reset your vote"

### DIFF
--- a/assets/i18n/active.en.json
+++ b/assets/i18n/active.en.json
@@ -32,10 +32,10 @@
   "poll.button.deletePoll": "Delete Poll",
   "poll.button.endPoll": "End Poll",
   "poll.button.resetVotes": {
-    "few": "Reset your votes",
-    "many": "Reset your votes",
-    "one": "Reset your vote",
-    "other": "Reset your votes"
+    "few": "Reset Your Votes",
+    "many": "Reset Your Votes",
+    "one": "Reset Your Vote",
+    "other": "Reset Your Votes"
   },
   "poll.endPost.answer.heading": {
     "few": "{{.Answer}} ({{.Count}} votes)",

--- a/server/poll/transform.go
+++ b/server/poll/transform.go
@@ -89,10 +89,10 @@ func (p *Poll) ToPostActions(bundle *utils.Bundle, pluginID, authorName string) 
 			Name: bundle.LocalizeWithConfig(localizer, &i18n.LocalizeConfig{
 				DefaultMessage: &i18n.Message{
 					ID:    "poll.button.resetVotes",
-					One:   "Reset your vote",
-					Few:   "Reset your votes",
-					Many:  "Reset your votes",
-					Other: "Reset your votes",
+					One:   "Reset Your Vote",
+					Few:   "Reset Your Votes",
+					Many:  "Reset Your Votes",
+					Other: "Reset Your Votes",
 				},
 				PluralCount: p.Settings.MaxVotes,
 			}),

--- a/server/poll/transform_test.go
+++ b/server/poll/transform_test.go
@@ -132,7 +132,7 @@ func TestPollToPostActions(t *testing.T) {
 					},
 				}, {
 					Id:    "resetVote",
-					Name:  "Reset your vote",
+					Name:  "Reset Your Vote",
 					Type:  model.PostActionTypeButton,
 					Style: "primary",
 					Integration: &model.PostActionIntegration{
@@ -198,7 +198,7 @@ func TestPollToPostActions(t *testing.T) {
 					},
 				}, {
 					Id:    "resetVote",
-					Name:  "Reset your vote",
+					Name:  "Reset Your Vote",
 					Type:  model.PostActionTypeButton,
 					Style: "primary",
 					Integration: &model.PostActionIntegration{
@@ -264,7 +264,7 @@ func TestPollToPostActions(t *testing.T) {
 					},
 				}, {
 					Id:    "resetVote",
-					Name:  "Reset your vote",
+					Name:  "Reset Your Vote",
 					Type:  model.PostActionTypeButton,
 					Style: "primary",
 					Integration: &model.PostActionIntegration{
@@ -330,7 +330,7 @@ func TestPollToPostActions(t *testing.T) {
 					},
 				}, {
 					Id:    "resetVote",
-					Name:  "Reset your votes",
+					Name:  "Reset Your Votes",
 					Type:  model.PostActionTypeButton,
 					Style: "primary",
 					Integration: &model.PostActionIntegration{

--- a/webapp/src/components/post_type/action_view/__snapshots__/action_view.test.jsx.snap
+++ b/webapp/src/components/post_type/action_view/__snapshots__/action_view.test.jsx.snap
@@ -45,7 +45,7 @@ exports[`components/post_type/action_view/ActionView should match snapshot 1`] =
       action={
         Object {
           "id": "resetVote",
-          "name": "Reset your vote",
+          "name": "Reset Your Vote",
           "type": "button",
         }
       }
@@ -165,7 +165,7 @@ exports[`components/post_type/action_view/ActionView should match snapshot with 
       action={
         Object {
           "id": "resetVote",
-          "name": "Reset your vote",
+          "name": "Reset Your Vote",
           "type": "button",
         }
       }
@@ -312,7 +312,7 @@ exports[`components/post_type/action_view/ActionView should match snapshot witho
       action={
         Object {
           "id": "resetVote",
-          "name": "Reset your vote",
+          "name": "Reset Your Vote",
           "type": "button",
         }
       }
@@ -372,7 +372,7 @@ exports[`components/post_type/action_view/ActionView should match snapshot witho
       action={
         Object {
           "id": "resetVote",
-          "name": "Reset your vote",
+          "name": "Reset Your Vote",
           "type": "button",
         }
       }

--- a/webapp/src/components/post_type/action_view/action_view.test.jsx
+++ b/webapp/src/components/post_type/action_view/action_view.test.jsx
@@ -1,177 +1,157 @@
-import React from "react";
-import { shallow } from "enzyme";
+import React from 'react';
+import {shallow} from 'enzyme';
 
-import { ActionButtonType } from "@/utils/constants";
+import {ActionButtonType} from '@/utils/constants';
 
-import ActionView from "@/components/post_type/action_view/action_view";
+import ActionView from '@/components/post_type/action_view/action_view';
 
-describe("components/post_type/action_view/ActionView", () => {
-  const samplePollId = "samplepollid1";
-  const baseProps = {
-    post: {
-      id: "post_id",
-      props: {
-        poll_id: samplePollId,
-      },
-    },
-    attachment: {
-      actions: [
-        { id: "action_id1", name: "answer1", type: ActionButtonType.BUTTON },
-        { id: "action_id2", name: "answer2", type: ActionButtonType.BUTTON },
-        { id: "action_id3", name: "answer3", type: ActionButtonType.BUTTON },
-        {
-          id: "resetVote",
-          name: "Reset Your Vote",
-          type: ActionButtonType.BUTTON,
+describe('components/post_type/action_view/ActionView', () => {
+    const samplePollId = 'samplepollid1';
+    const baseProps = {
+        post: {
+            id: 'post_id',
+            props: {
+                poll_id: samplePollId,
+            },
         },
-        { id: "addOption", name: "Add option", type: ActionButtonType.BUTTON },
-        {
-          id: "deletePoll",
-          name: "Delete Poll",
-          type: ActionButtonType.MATTERPOLL_ADMIN_BUTTON,
+        attachment: {
+            actions: [
+                {id: 'action_id1', name: 'answer1', type: ActionButtonType.BUTTON},
+                {id: 'action_id2', name: 'answer2', type: ActionButtonType.BUTTON},
+                {id: 'action_id3', name: 'answer3', type: ActionButtonType.BUTTON},
+                {id: 'resetVote', name: 'Reset your vote', type: ActionButtonType.BUTTON},
+                {id: 'addOption', name: 'Add option', type: ActionButtonType.BUTTON},
+                {id: 'deletePoll', name: 'Delete Poll', type: ActionButtonType.MATTERPOLL_ADMIN_BUTTON},
+                {id: 'endPoll', name: 'End Poll', type: ActionButtonType.MATTERPOLL_ADMIN_BUTTON},
+            ],
         },
-        {
-          id: "endPoll",
-          name: "End Poll",
-          type: ActionButtonType.MATTERPOLL_ADMIN_BUTTON,
+        pollMetadata: {
+            samplepollid1: {
+                voted_answers: ['answer1', 'answer2'],
+                poll_id: samplePollId,
+                user_id: 'user_id1',
+                can_manage_poll: false,
+                setting_progress: false,
+                setting_public_add_option: false,
+            },
         },
-      ],
-    },
-    pollMetadata: {
-      samplepollid1: {
-        voted_answers: ["answer1", "answer2"],
-        poll_id: samplePollId,
-        user_id: "user_id1",
-        can_manage_poll: false,
-        setting_progress: false,
-        setting_public_add_option: false,
-      },
-    },
-    siteUrl: "http://localhost:8065",
-    actions: {
-      fetchPollMetadata: jest.fn(),
-    },
-  };
+        siteUrl: 'http://localhost:8065',
+        actions: {
+            fetchPollMetadata: jest.fn(),
+        },
+    };
 
-  test("should match snapshot", () => {
-    const wrapper = shallow(<ActionView {...baseProps} />);
-    expect(wrapper).toMatchSnapshot();
-  });
-  test("should match snapshot with permission to manage poll", () => {
-    const newProps = {
-      ...baseProps,
-      pollMetadata: {
-        samplepollid1: {
-          voted_answers: ["answer1", "answer2"],
-          poll_id: samplePollId,
-          user_id: "user_id1",
-          can_manage_poll: true,
-        },
-      },
-    };
-    const wrapper = shallow(<ActionView {...newProps} />);
-    expect(wrapper).toMatchSnapshot();
-  });
-  test("should match snapshot without permission for adding options", () => {
-    const newProps = {
-      ...baseProps,
-      pollMetadata: {
-        samplepollid1: {
-          voted_answers: ["answer1", "answer2"],
-          poll_id: samplePollId,
-          user_id: "user_id1",
-          can_manage_poll: false,
-          setting_progress: false,
-          setting_public_add_option: false,
-        },
-      },
-    };
-    const wrapper = shallow(<ActionView {...newProps} />);
-    expect(wrapper).toMatchSnapshot();
-  });
-  test("should match snapshot without permission to manage poll, with public-add-option", () => {
-    const newProps = {
-      ...baseProps,
-      pollMetadata: {
-        samplepollid1: {
-          voted_answers: ["answer1", "answer2"],
-          poll_id: samplePollId,
-          user_id: "user_id1",
-          can_manage_poll: false,
-          setting_progress: false,
-          setting_public_add_option: true,
-        },
-      },
-    };
-    const wrapper = shallow(<ActionView {...newProps} />);
-    expect(wrapper).toMatchSnapshot();
-  });
-  test("should match snapshot with setting_progress", () => {
-    const newProps = {
-      ...baseProps,
-      attachment: {
-        actions: [
-          {
-            id: "action_id1",
-            name: "answer1 (1)",
-            type: ActionButtonType.BUTTON,
-          },
-          {
-            id: "action_id2",
-            name: "answer2 (12)",
-            type: ActionButtonType.BUTTON,
-          },
-          { id: "action_id3", name: "answer3", type: ActionButtonType.BUTTON },
-        ],
-      },
-      pollMetadata: {
-        samplepollid1: {
-          voted_answers: ["answer1", "answer3"],
-          poll_id: samplePollId,
-          user_id: "user_id1",
-          can_manage_poll: false,
-          setting_progress: true,
-          setting_public_add_option: false,
-        },
-      },
-    };
-    const wrapper = shallow(<ActionView {...newProps} />);
-    expect(wrapper).toMatchSnapshot();
-  });
-  test("should match snapshot without any actions", () => {
-    const newProps = {
-      ...baseProps,
-      attachment: { actions: [] },
-    };
-    const wrapper = shallow(<ActionView {...newProps} />);
-    expect(wrapper).toMatchSnapshot();
-  });
-  test("should match snapshot with only button actions", () => {
-    const newProps = {
-      ...baseProps,
-      attachment: {
-        actions: [
-          { id: "action_id1", name: "answer1", type: ActionButtonType.BUTTON },
-          { id: "action_id2", name: "answer2", type: ActionButtonType.SELECT },
-        ],
-      },
-    };
-    const wrapper = shallow(<ActionView {...newProps} />);
-    expect(wrapper).toMatchSnapshot();
-  });
-  test("should match snapshot with only non-empty aciton id and name", () => {
-    const newProps = {
-      ...baseProps,
-      attachment: {
-        actions: [
-          { id: "action_id1", name: "answer1", type: ActionButtonType.BUTTON },
-          { id: "action_id2", name: "", type: ActionButtonType.BUTTON },
-          { id: "", name: "answer3", type: ActionButtonType.BUTTON },
-          { id: "action_id4", name: "answer4", type: ActionButtonType.BUTTON },
-        ],
-      },
-    };
-    const wrapper = shallow(<ActionView {...newProps} />);
-    expect(wrapper).toMatchSnapshot();
-  });
+    test('should match snapshot', () => {
+        const wrapper = shallow(<ActionView {...baseProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+    test('should match snapshot with permission to manage poll', () => {
+        const newProps = {
+            ...baseProps,
+            pollMetadata: {
+                samplepollid1: {
+                    voted_answers: ['answer1', 'answer2'],
+                    poll_id: samplePollId,
+                    user_id: 'user_id1',
+                    can_manage_poll: true,
+                },
+            },
+        };
+        const wrapper = shallow(<ActionView {...newProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+    test('should match snapshot without permission for adding options', () => {
+        const newProps = {
+            ...baseProps,
+            pollMetadata: {
+                samplepollid1: {
+                    voted_answers: ['answer1', 'answer2'],
+                    poll_id: samplePollId,
+                    user_id: 'user_id1',
+                    can_manage_poll: false,
+                    setting_progress: false,
+                    setting_public_add_option: false,
+                },
+            },
+        };
+        const wrapper = shallow(<ActionView {...newProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+    test('should match snapshot without permission to manage poll, with public-add-option', () => {
+        const newProps = {
+            ...baseProps,
+            pollMetadata: {
+                samplepollid1: {
+                    voted_answers: ['answer1', 'answer2'],
+                    poll_id: samplePollId,
+                    user_id: 'user_id1',
+                    can_manage_poll: false,
+                    setting_progress: false,
+                    setting_public_add_option: true,
+                },
+            },
+        };
+        const wrapper = shallow(<ActionView {...newProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+    test('should match snapshot with setting_progress', () => {
+        const newProps = {
+            ...baseProps,
+            attachment: {
+                actions: [
+                    {id: 'action_id1', name: 'answer1 (1)', type: ActionButtonType.BUTTON},
+                    {id: 'action_id2', name: 'answer2 (12)', type: ActionButtonType.BUTTON},
+                    {id: 'action_id3', name: 'answer3', type: ActionButtonType.BUTTON},
+                ],
+            },
+            pollMetadata: {
+                samplepollid1: {
+                    voted_answers: ['answer1', 'answer3'],
+                    poll_id: samplePollId,
+                    user_id: 'user_id1',
+                    can_manage_poll: false,
+                    setting_progress: true,
+                    setting_public_add_option: false,
+                },
+            },
+        };
+        const wrapper = shallow(<ActionView {...newProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+    test('should match snapshot without any actions', () => {
+        const newProps = {
+            ...baseProps,
+            attachment: {actions: []},
+        };
+        const wrapper = shallow(<ActionView {...newProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+    test('should match snapshot with only button actions', () => {
+        const newProps = {
+            ...baseProps,
+            attachment: {
+                actions: [
+                    {id: 'action_id1', name: 'answer1', type: ActionButtonType.BUTTON},
+                    {id: 'action_id2', name: 'answer2', type: ActionButtonType.SELECT},
+                ],
+            },
+        };
+        const wrapper = shallow(<ActionView {...newProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+    test('should match snapshot with only non-empty aciton id and name', () => {
+        const newProps = {
+            ...baseProps,
+            attachment: {
+                actions: [
+                    {id: 'action_id1', name: 'answer1', type: ActionButtonType.BUTTON},
+                    {id: 'action_id2', name: '', type: ActionButtonType.BUTTON},
+                    {id: '', name: 'answer3', type: ActionButtonType.BUTTON},
+                    {id: 'action_id4', name: 'answer4', type: ActionButtonType.BUTTON},
+                ],
+            },
+        };
+        const wrapper = shallow(<ActionView {...newProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
 });

--- a/webapp/src/components/post_type/action_view/action_view.test.jsx
+++ b/webapp/src/components/post_type/action_view/action_view.test.jsx
@@ -19,7 +19,7 @@ describe('components/post_type/action_view/ActionView', () => {
                 {id: 'action_id1', name: 'answer1', type: ActionButtonType.BUTTON},
                 {id: 'action_id2', name: 'answer2', type: ActionButtonType.BUTTON},
                 {id: 'action_id3', name: 'answer3', type: ActionButtonType.BUTTON},
-                {id: 'resetVote', name: 'Reset your vote', type: ActionButtonType.BUTTON},
+                {id: 'resetVote', name: 'Reset Your Vote', type: ActionButtonType.BUTTON},
                 {id: 'addOption', name: 'Add option', type: ActionButtonType.BUTTON},
                 {id: 'deletePoll', name: 'Delete Poll', type: ActionButtonType.MATTERPOLL_ADMIN_BUTTON},
                 {id: 'endPoll', name: 'End Poll', type: ActionButtonType.MATTERPOLL_ADMIN_BUTTON},

--- a/webapp/src/components/post_type/action_view/action_view.test.jsx
+++ b/webapp/src/components/post_type/action_view/action_view.test.jsx
@@ -1,157 +1,177 @@
-import React from 'react';
-import {shallow} from 'enzyme';
+import React from "react";
+import { shallow } from "enzyme";
 
-import {ActionButtonType} from '@/utils/constants';
+import { ActionButtonType } from "@/utils/constants";
 
-import ActionView from '@/components/post_type/action_view/action_view';
+import ActionView from "@/components/post_type/action_view/action_view";
 
-describe('components/post_type/action_view/ActionView', () => {
-    const samplePollId = 'samplepollid1';
-    const baseProps = {
-        post: {
-            id: 'post_id',
-            props: {
-                poll_id: samplePollId,
-            },
+describe("components/post_type/action_view/ActionView", () => {
+  const samplePollId = "samplepollid1";
+  const baseProps = {
+    post: {
+      id: "post_id",
+      props: {
+        poll_id: samplePollId,
+      },
+    },
+    attachment: {
+      actions: [
+        { id: "action_id1", name: "answer1", type: ActionButtonType.BUTTON },
+        { id: "action_id2", name: "answer2", type: ActionButtonType.BUTTON },
+        { id: "action_id3", name: "answer3", type: ActionButtonType.BUTTON },
+        {
+          id: "resetVote",
+          name: "Reset Your Vote",
+          type: ActionButtonType.BUTTON,
         },
-        attachment: {
-            actions: [
-                {id: 'action_id1', name: 'answer1', type: ActionButtonType.BUTTON},
-                {id: 'action_id2', name: 'answer2', type: ActionButtonType.BUTTON},
-                {id: 'action_id3', name: 'answer3', type: ActionButtonType.BUTTON},
-                {id: 'resetVote', name: 'Reset your vote', type: ActionButtonType.BUTTON},
-                {id: 'addOption', name: 'Add option', type: ActionButtonType.BUTTON},
-                {id: 'deletePoll', name: 'Delete Poll', type: ActionButtonType.MATTERPOLL_ADMIN_BUTTON},
-                {id: 'endPoll', name: 'End Poll', type: ActionButtonType.MATTERPOLL_ADMIN_BUTTON},
-            ],
+        { id: "addOption", name: "Add option", type: ActionButtonType.BUTTON },
+        {
+          id: "deletePoll",
+          name: "Delete Poll",
+          type: ActionButtonType.MATTERPOLL_ADMIN_BUTTON,
         },
-        pollMetadata: {
-            samplepollid1: {
-                voted_answers: ['answer1', 'answer2'],
-                poll_id: samplePollId,
-                user_id: 'user_id1',
-                can_manage_poll: false,
-                setting_progress: false,
-                setting_public_add_option: false,
-            },
+        {
+          id: "endPoll",
+          name: "End Poll",
+          type: ActionButtonType.MATTERPOLL_ADMIN_BUTTON,
         },
-        siteUrl: 'http://localhost:8065',
-        actions: {
-            fetchPollMetadata: jest.fn(),
+      ],
+    },
+    pollMetadata: {
+      samplepollid1: {
+        voted_answers: ["answer1", "answer2"],
+        poll_id: samplePollId,
+        user_id: "user_id1",
+        can_manage_poll: false,
+        setting_progress: false,
+        setting_public_add_option: false,
+      },
+    },
+    siteUrl: "http://localhost:8065",
+    actions: {
+      fetchPollMetadata: jest.fn(),
+    },
+  };
+
+  test("should match snapshot", () => {
+    const wrapper = shallow(<ActionView {...baseProps} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  test("should match snapshot with permission to manage poll", () => {
+    const newProps = {
+      ...baseProps,
+      pollMetadata: {
+        samplepollid1: {
+          voted_answers: ["answer1", "answer2"],
+          poll_id: samplePollId,
+          user_id: "user_id1",
+          can_manage_poll: true,
         },
+      },
     };
-
-    test('should match snapshot', () => {
-        const wrapper = shallow(<ActionView {...baseProps}/>);
-        expect(wrapper).toMatchSnapshot();
-    });
-    test('should match snapshot with permission to manage poll', () => {
-        const newProps = {
-            ...baseProps,
-            pollMetadata: {
-                samplepollid1: {
-                    voted_answers: ['answer1', 'answer2'],
-                    poll_id: samplePollId,
-                    user_id: 'user_id1',
-                    can_manage_poll: true,
-                },
-            },
-        };
-        const wrapper = shallow(<ActionView {...newProps}/>);
-        expect(wrapper).toMatchSnapshot();
-    });
-    test('should match snapshot without permission for adding options', () => {
-        const newProps = {
-            ...baseProps,
-            pollMetadata: {
-                samplepollid1: {
-                    voted_answers: ['answer1', 'answer2'],
-                    poll_id: samplePollId,
-                    user_id: 'user_id1',
-                    can_manage_poll: false,
-                    setting_progress: false,
-                    setting_public_add_option: false,
-                },
-            },
-        };
-        const wrapper = shallow(<ActionView {...newProps}/>);
-        expect(wrapper).toMatchSnapshot();
-    });
-    test('should match snapshot without permission to manage poll, with public-add-option', () => {
-        const newProps = {
-            ...baseProps,
-            pollMetadata: {
-                samplepollid1: {
-                    voted_answers: ['answer1', 'answer2'],
-                    poll_id: samplePollId,
-                    user_id: 'user_id1',
-                    can_manage_poll: false,
-                    setting_progress: false,
-                    setting_public_add_option: true,
-                },
-            },
-        };
-        const wrapper = shallow(<ActionView {...newProps}/>);
-        expect(wrapper).toMatchSnapshot();
-    });
-    test('should match snapshot with setting_progress', () => {
-        const newProps = {
-            ...baseProps,
-            attachment: {
-                actions: [
-                    {id: 'action_id1', name: 'answer1 (1)', type: ActionButtonType.BUTTON},
-                    {id: 'action_id2', name: 'answer2 (12)', type: ActionButtonType.BUTTON},
-                    {id: 'action_id3', name: 'answer3', type: ActionButtonType.BUTTON},
-                ],
-            },
-            pollMetadata: {
-                samplepollid1: {
-                    voted_answers: ['answer1', 'answer3'],
-                    poll_id: samplePollId,
-                    user_id: 'user_id1',
-                    can_manage_poll: false,
-                    setting_progress: true,
-                    setting_public_add_option: false,
-                },
-            },
-        };
-        const wrapper = shallow(<ActionView {...newProps}/>);
-        expect(wrapper).toMatchSnapshot();
-    });
-    test('should match snapshot without any actions', () => {
-        const newProps = {
-            ...baseProps,
-            attachment: {actions: []},
-        };
-        const wrapper = shallow(<ActionView {...newProps}/>);
-        expect(wrapper).toMatchSnapshot();
-    });
-    test('should match snapshot with only button actions', () => {
-        const newProps = {
-            ...baseProps,
-            attachment: {
-                actions: [
-                    {id: 'action_id1', name: 'answer1', type: ActionButtonType.BUTTON},
-                    {id: 'action_id2', name: 'answer2', type: ActionButtonType.SELECT},
-                ],
-            },
-        };
-        const wrapper = shallow(<ActionView {...newProps}/>);
-        expect(wrapper).toMatchSnapshot();
-    });
-    test('should match snapshot with only non-empty aciton id and name', () => {
-        const newProps = {
-            ...baseProps,
-            attachment: {
-                actions: [
-                    {id: 'action_id1', name: 'answer1', type: ActionButtonType.BUTTON},
-                    {id: 'action_id2', name: '', type: ActionButtonType.BUTTON},
-                    {id: '', name: 'answer3', type: ActionButtonType.BUTTON},
-                    {id: 'action_id4', name: 'answer4', type: ActionButtonType.BUTTON},
-                ],
-            },
-        };
-        const wrapper = shallow(<ActionView {...newProps}/>);
-        expect(wrapper).toMatchSnapshot();
-    });
+    const wrapper = shallow(<ActionView {...newProps} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  test("should match snapshot without permission for adding options", () => {
+    const newProps = {
+      ...baseProps,
+      pollMetadata: {
+        samplepollid1: {
+          voted_answers: ["answer1", "answer2"],
+          poll_id: samplePollId,
+          user_id: "user_id1",
+          can_manage_poll: false,
+          setting_progress: false,
+          setting_public_add_option: false,
+        },
+      },
+    };
+    const wrapper = shallow(<ActionView {...newProps} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  test("should match snapshot without permission to manage poll, with public-add-option", () => {
+    const newProps = {
+      ...baseProps,
+      pollMetadata: {
+        samplepollid1: {
+          voted_answers: ["answer1", "answer2"],
+          poll_id: samplePollId,
+          user_id: "user_id1",
+          can_manage_poll: false,
+          setting_progress: false,
+          setting_public_add_option: true,
+        },
+      },
+    };
+    const wrapper = shallow(<ActionView {...newProps} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  test("should match snapshot with setting_progress", () => {
+    const newProps = {
+      ...baseProps,
+      attachment: {
+        actions: [
+          {
+            id: "action_id1",
+            name: "answer1 (1)",
+            type: ActionButtonType.BUTTON,
+          },
+          {
+            id: "action_id2",
+            name: "answer2 (12)",
+            type: ActionButtonType.BUTTON,
+          },
+          { id: "action_id3", name: "answer3", type: ActionButtonType.BUTTON },
+        ],
+      },
+      pollMetadata: {
+        samplepollid1: {
+          voted_answers: ["answer1", "answer3"],
+          poll_id: samplePollId,
+          user_id: "user_id1",
+          can_manage_poll: false,
+          setting_progress: true,
+          setting_public_add_option: false,
+        },
+      },
+    };
+    const wrapper = shallow(<ActionView {...newProps} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  test("should match snapshot without any actions", () => {
+    const newProps = {
+      ...baseProps,
+      attachment: { actions: [] },
+    };
+    const wrapper = shallow(<ActionView {...newProps} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  test("should match snapshot with only button actions", () => {
+    const newProps = {
+      ...baseProps,
+      attachment: {
+        actions: [
+          { id: "action_id1", name: "answer1", type: ActionButtonType.BUTTON },
+          { id: "action_id2", name: "answer2", type: ActionButtonType.SELECT },
+        ],
+      },
+    };
+    const wrapper = shallow(<ActionView {...newProps} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  test("should match snapshot with only non-empty aciton id and name", () => {
+    const newProps = {
+      ...baseProps,
+      attachment: {
+        actions: [
+          { id: "action_id1", name: "answer1", type: ActionButtonType.BUTTON },
+          { id: "action_id2", name: "", type: ActionButtonType.BUTTON },
+          { id: "", name: "answer3", type: ActionButtonType.BUTTON },
+          { id: "action_id4", name: "answer4", type: ActionButtonType.BUTTON },
+        ],
+      },
+    };
+    const wrapper = shallow(<ActionView {...newProps} />);
+    expect(wrapper).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
There was an inconsistent capitalization between "Reset your vote" and "Add Option", "End Poll", "Delete Poll". Now  "Reset your vote" has been replaced with  "Reset Your Vote".

Closes #497 