### PR TITLE
Add missing executables to plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -11,7 +11,9 @@
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",
+            "linux-arm64": "server/dist/plugin-linux-arm64",
             "darwin-amd64": "server/dist/plugin-darwin-amd64",
+            "darwin-arm64": "server/dist/plugin-darwin-arm64",
             "windows-amd64": "server/dist/plugin-windows-amd64.exe"
         }
     },


### PR DESCRIPTION
I tried to run the plugin on arm64, it didn't work, I noticed that there are actually arm64 builds in the server/dist folder, but they are missing from the plugin.json. Patched it and so far it seems to work