### PR TITLE
Reduce amount of monkey patching

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -311,7 +311,7 @@ func (p *MatterpollPlugin) handleCreatePoll(_ map[string]string, request *model.
 	userLocalizer := p.bundle.GetUserLocalizer(creatorID)
 
 	settings := poll.NewSettingsFromSubmission(request.Submission)
-	poll, errMsg := poll.NewPoll(creatorID, question, answerOptions, settings)
+	poll, errMsg := p.pf.NewPoll(creatorID, question, answerOptions, settings)
 	if errMsg != nil {
 		response := &model.SubmitDialogResponse{
 			Error: p.bundle.LocalizeErrorMessage(userLocalizer, errMsg),

--- a/server/plugin/api_test.go
+++ b/server/plugin/api_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"github.com/undefinedlabs/go-mpatch"
 
 	root "github.com/matterpoll/matterpoll"
 	"github.com/matterpoll/matterpoll/server/poll"
@@ -541,11 +540,8 @@ func TestHandleCreatePoll(t *testing.T) {
 			store := test.SetupStore(&mockstore.Store{})
 			defer store.AssertExpectations(t)
 			p := setupTestPlugin(t, api, store)
-
-			patch1, _ := mpatch.PatchMethod(model.GetMillis, func() int64 { return 1234567890 })
-			patch2, _ := mpatch.PatchMethod(model.NewId, testutils.GetPollID)
-			defer func() { require.NoError(t, patch1.Unpatch()) }()
-			defer func() { require.NoError(t, patch2.Unpatch()) }()
+			p.pf.SetNewID(testutils.GetPollID)
+			p.pf.SetMillis(testutils.GetMillis)
 
 			w := httptest.NewRecorder()
 			url := "/api/v1/polls/create"

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -161,9 +161,9 @@ func (p *MatterpollPlugin) executeCommand(args *model.CommandArgs) (string, *mod
 
 	var newPoll *poll.Poll
 	if len(o) == 0 {
-		newPoll, errMsg = poll.NewPoll(creatorID, q, []string{defaultYes, defaultNo}, settings)
+		newPoll, errMsg = p.pf.NewPoll(creatorID, q, []string{defaultYes, defaultNo}, settings)
 	} else {
-		newPoll, errMsg = poll.NewPoll(creatorID, q, o, settings)
+		newPoll, errMsg = p.pf.NewPoll(creatorID, q, o, settings)
 	}
 	if errMsg != nil {
 		appErr := &model.AppError{

--- a/server/plugin/command_test.go
+++ b/server/plugin/command_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/undefinedlabs/go-mpatch"
 
 	root "github.com/matterpoll/matterpoll"
 	"github.com/matterpoll/matterpoll/server/poll"
@@ -405,10 +403,8 @@ func TestPluginExecuteCommand(t *testing.T) {
 			p := setupTestPlugin(t, api, store)
 			p.configuration.Trigger = trigger
 
-			patch1, _ := mpatch.PatchMethod(model.GetMillis, func() int64 { return 1234567890 })
-			patch2, _ := mpatch.PatchMethod(model.NewId, testutils.GetPollID)
-			defer func() { require.NoError(t, patch1.Unpatch()) }()
-			defer func() { require.NoError(t, patch2.Unpatch()) }()
+			p.pf.SetNewID(testutils.GetPollID)
+			p.pf.SetMillis(testutils.GetMillis)
 
 			r, err := p.ExecuteCommand(nil, &model.CommandArgs{
 				Command:   test.Command,

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -40,6 +40,8 @@ type MatterpollPlugin struct {
 
 	// getIconData provides access to command.GetIconData in a way that is mockable for unit testing.
 	getIconData func() (string, error)
+
+	pf poll.Factory
 }
 
 var botDescription = &i18n.Message{

--- a/server/plugin/plugin_test.go
+++ b/server/plugin/plugin_test.go
@@ -225,11 +225,6 @@ func TestPluginOnActivate(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
 
-		patch, _ := mpatch.PatchMethod(kvstore.NewStore, func(plugin.API, string) (store.Store, error) {
-			return nil, &model.AppError{}
-		})
-		defer func() { require.NoError(t, patch.Unpatch()) }()
-
 		p := &MatterpollPlugin{
 			ServerConfig: &model.Config{
 				ServiceSettings: model.ServiceSettings{

--- a/server/poll/poll.go
+++ b/server/poll/poll.go
@@ -46,11 +46,45 @@ type Settings struct {
 	MaxVotes        int `json:"max_votes"`
 }
 
+// Factory is used to create a new [Poll].
+type Factory struct {
+	newID     func() string
+	getMillis func() int64
+}
+
+func (fac *Factory) NewID() string {
+	if fac.newID != nil {
+		return fac.newID()
+	}
+
+	return model.NewId()
+}
+
+// SetNewID allows overwritting the function used to generate new poll IDs.
+// It only use is for testing.
+func (fac *Factory) SetNewID(f func() string) {
+	fac.newID = f
+}
+
+func (fac *Factory) Millis() int64 {
+	if fac.getMillis != nil {
+		return fac.getMillis()
+	}
+
+	return model.GetMillis()
+}
+
+// SetMillis allows overwritting the function used to fetch the current time.
+// It only use is for testing.
+func (fac *Factory) SetMillis(f func() int64) {
+	fac.getMillis = f
+}
+
 // NewPoll creates a new poll with the given parameter.
-func NewPoll(creator, question string, answerOptions []string, settings Settings) (*Poll, *utils.ErrorMessage) {
+func (fac *Factory) NewPoll(creator, question string, answerOptions []string, settings Settings) (*Poll, *utils.ErrorMessage) {
 	p := Poll{
-		ID:        model.NewId(),
-		CreatedAt: model.GetMillis(),
+		ID:        fac.NewID(),
+		CreatedAt: fac.Millis(),
 		Creator:   creator,
 		Question:  question,
 		Settings:  settings,

--- a/server/utils/testutils/data.go
+++ b/server/utils/testutils/data.go
@@ -11,6 +11,11 @@ func GetPollID() string {
 	return "1234567890abcdefghij"
 }
 
+// GetPollID returns a number of milliseconds in unix time.
+func GetMillis() int64 {
+	return 1234567890
+}
+
 // GetSiteURL returns a static Site URL.
 func GetSiteURL() string {
 	return "https://example.org"
@@ -47,7 +52,7 @@ func GetPoll() *poll.Poll {
 	return &poll.Poll{
 		ID:        GetPollID(),
 		PostID:    "postID1",
-		CreatedAt: 1234567890,
+		CreatedAt: GetMillis(),
 		Creator:   "userID1",
 		Question:  "Question",
 		AnswerOptions: []*poll.AnswerOption{{
@@ -83,7 +88,7 @@ func GetPollWithVotes() *poll.Poll {
 	return &poll.Poll{
 		ID:        GetPollID(),
 		PostID:    "postID1",
-		CreatedAt: 1234567890,
+		CreatedAt: GetMillis(),
 		Creator:   "userID1",
 		Question:  "Question",
 		AnswerOptions: []*poll.AnswerOption{{
@@ -105,7 +110,7 @@ func GetPollWithVoteUnknownUser() *poll.Poll {
 	return &poll.Poll{
 		ID:        GetPollID(),
 		PostID:    "postID1",
-		CreatedAt: 1234567890,
+		CreatedAt: GetMillis(),
 		Creator:   "userID1",
 		Question:  "Question",
 		AnswerOptions: []*poll.AnswerOption{{
@@ -134,7 +139,7 @@ func GetPollTwoOptions() *poll.Poll {
 	return &poll.Poll{
 		ID:        GetPollID(),
 		PostID:    "postID1",
-		CreatedAt: 1234567890,
+		CreatedAt: GetMillis(),
 		Creator:   "userID1",
 		Question:  "Question",
 		AnswerOptions: []*poll.AnswerOption{{


### PR DESCRIPTION
Monkey patching is a bad practice. We should avoid it as much as possible.

This PR introduces a `poll.Factory` that takes care of the poll creation. In tests, setters can be used to modify the behaviour.

The only test that still needs to get migrated is `TestPluginOnActivate`, which is a PITA to do without dropping coverage. Maybe it's worth removing some test cases if that gets us away from monkey patching.