### PR TITLE
Introduce community-plugin-ci/cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,18 @@
+name: cd
+on:
+  workflow_run:
+    workflows: ["ci"]
+    branches-ignore: ["*"]
+    types:
+      - completed
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  plugin-cd:
+    uses: mattermost/actions-workflows/.github/workflows/community-plugin-cd.yml@ce05ecbb0c51643e1cffb7834469df74ab68dae5
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,27 +14,5 @@ permissions:
 
 jobs:
   plugin-ci:
-    uses: mattermost/actions-workflows/.github/workflows/plugin-ci.yml@main
+    uses: mattermost/actions-workflows/.github/workflows/community-plugin-ci.yml@ce05ecbb0c51643e1cffb7834469df74ab68dae5
     secrets: inherit
-  release-github:
-    # Forked from https://github.com/mattermost/actions-workflows/blob/ad122fe2bb8496d80eff5341d6b26a41a447a006/.github/workflows/plugin-cd.yml#L88
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-22.04
-    needs: [plugin-ci]
-    steps:
-      - name: cd/checkout-repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-        with:
-          fetch-depth: "0"
-      - name: ci/download-artifact
-        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
-        with:
-          name: dist
-          path: dist
-      - name: ci/publish-release
-        run: |
-          gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file release-notes.md  *.tar.gz
-        working-directory: dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  


### PR DESCRIPTION
https://github.com/matterpoll/matterpoll/actions/runs/9129665836/job/25104751370#step:4:210
https://github.com/matterpoll/matterpoll/actions/runs/9129665836/job/25104922063#step:3:1
Release job was failed, (I guess) because of version conflicts between `actions/upload-artifact (v4)` and `actions/download-artifact (v3)`.   

Current workflow uses `mattermost/actions-workflows/.github/workflows/plugin-ci.yml@main` which depends `actions/upload-artifact (v4)`, and hard-coded `actions/download-artifact (v3)`.  
https://github.com/matterpoll/matterpoll/blob/0fbc18bf48371954a386098d7793694d1196d6e4/.github/workflows/ci.yml#L30

This PR introduce `community-plugin-ci/cd.yml` and version conflicts would be resolved (https://github.com/mattermost/actions-workflows/pull/44 was merged at nicely timing). Additionally, this can fix #549 .
