### PR TITLE
Set omitempty to AnonymousCreator setting

### DIFF
--- a/server/poll/poll.go
+++ b/server/poll/poll.go
@@ -23,6 +23,8 @@ const (
 )
 
 // Poll stores all needed information for a poll
+// When adding new fields, to avoid failures during atomic transactions for KV Store,
+// either specify omitempty or set initial values during the upgrade.
 type Poll struct {
 	ID            string
 	PostID        string `json:"post_id,omitempty"`
@@ -39,10 +41,12 @@ type AnswerOption struct {
 	Voter  []string
 }
 
-// Settings stores possible settings for a poll
+// Settings stores possible settings for a poll.
+// When adding new settings, to avoid failures during atomic transactions for KV Store,
+// either specify omitempty or set initial values during the upgrade.
 type Settings struct {
 	Anonymous        bool
-	AnonymousCreator bool `json:",omitempty"`
+	AnonymousCreator bool `json:",omitempty"` // Since v1.7
 	Progress         bool
 	PublicAddOption  bool
 	MaxVotes         int `json:"max_votes"`

--- a/server/poll/poll.go
+++ b/server/poll/poll.go
@@ -42,7 +42,7 @@ type AnswerOption struct {
 // Settings stores possible settings for a poll
 type Settings struct {
 	Anonymous        bool
-	AnonymousCreator bool
+	AnonymousCreator bool `json:",omitempty"`
 	Progress         bool
 	PublicAddOption  bool
 	MaxVotes         int `json:"max_votes"`

--- a/server/poll/poll.go
+++ b/server/poll/poll.go
@@ -46,7 +46,7 @@ type AnswerOption struct {
 // either specify omitempty or set initial values during the upgrade.
 type Settings struct {
 	Anonymous        bool
-	AnonymousCreator bool `json:",omitempty"` // Since v1.7
+	AnonymousCreator bool `json:",omitempty"`
 	Progress         bool
 	PublicAddOption  bool
 	MaxVotes         int `json:"max_votes"`


### PR DESCRIPTION
fix #562 

## Summary
Since the poll craeted by Matterpoll v1.6 or before doens't have `AnonymousCreator` setting, atomic transaction will be failed. Set omitempty to `AnonymousCreator` to avoid this error.

After merging this, get ready for releasing v1.7.1.

---

An upgrade script to update data within the KV Store could be considered, but it would need to be run every time a release that has new field for Poll/Settings. Therefore, a simpler approach using omitempty was adopted. The upgrade script will only be used when it is necessary to set specific initial values.