### PR TITLE
Add upgrade script to add AnonymousCreator setting to existing polls

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,9 +4,9 @@
     "description": "Create polls and surveys directly within Mattermost.",
     "homepage_url": "https://github.com/matterpoll/matterpoll",
     "support_url": "https://github.com/matterpoll/matterpoll/issues",
-    "release_notes_url": "https://github.com/matterpoll/matterpoll/releases/tag/v1.7.1",
+    "release_notes_url": "https://github.com/matterpoll/matterpoll/releases/tag/v1.7.2",
     "icon_path": "assets/logo_dark.svg",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "min_server_version": "8.1.0",
     "server": {
         "executables": {

--- a/server/store/kvstore/store_test.go
+++ b/server/store/kvstore/store_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const latestVersion = "1.7.1"
+const latestVersion = "1.7.2"
 
 func setupTestStore(api plugin.API) *Store {
 	store := Store{

--- a/server/store/kvstore/upgrade.go
+++ b/server/store/kvstore/upgrade.go
@@ -126,9 +126,10 @@ func upgradeTo14(s *Store) error {
 
 // upgradeTo17_2 convert existing polls to the new format that includes `Settings.AnonymousCreator` setting.
 //
-// Adding new settings (AnonymousCreator) without `omitempty` causes the atomic transaction to fail when saving a poll.
-// Additinally, just adding `omitempty` to Settings.AnonymousCreator will also result in atomic transactions failure
-// for poll with AnonymousCreator=false, which is created with Matterpoll v1.7.0.
+// New setting `AnonymousCreator“ without `omitempty` introduced in v1.7.0 causes the atomic transaction
+// to fail when saving a poll. Additionally, just adding `omitempty` to Settings.AnonymousCreator introduced
+// in v1.7.1 will also result in atomic transactions failure for poll with AnonymousCreator=false, which is
+// created with Matterpoll v1.7.0.
 // => see https://github.com/matterpoll/matterpoll/issues/562
 func upgradeTo17_2(s *Store) error {
 	var allKeys []string
@@ -153,6 +154,7 @@ func upgradeTo17_2(s *Store) error {
 		if strings.HasPrefix(k, pollPrefix) {
 			k = strings.TrimPrefix(k, pollPrefix)
 
+			// poll is migrated when reading data
 			poll, err := s.Poll().Get(k)
 			if err != nil {
 				s.api.LogError("Failed to get poll for migration", "error", err.Error(), "pollID", k)

--- a/server/store/kvstore/upgrade.go
+++ b/server/store/kvstore/upgrade.go
@@ -28,6 +28,7 @@ func getUpgrades() []*upgrade {
 		{toVersion: "1.6.1", upgradeFunc: nil},
 		{toVersion: "1.7.0", upgradeFunc: nil},
 		{toVersion: "1.7.1", upgradeFunc: nil},
+		{toVersion: "1.7.2", upgradeFunc: upgradeTo17_2},
 	}
 }
 
@@ -112,6 +113,52 @@ func upgradeTo14(s *Store) error {
 			}
 
 			poll.Settings.MaxVotes = 1
+			err = s.Poll().Save(poll)
+			if err != nil {
+				s.api.LogError("Failed to save poll after migration", "error", err.Error(), "pollID", k)
+				continue
+			}
+		}
+	}
+
+	return nil
+}
+
+// upgradeTo17_2 convert existing polls to the new format that includes `Settings.AnonymousCreator` setting.
+//
+// Adding new settings (AnonymousCreator) without `omitempty` causes the atomic transaction to fail when saving a poll.
+// Additinally, just adding `omitempty` to Settings.AnonymousCreator will also result in atomic transactions failure
+// for poll with AnonymousCreator=false, which is created with Matterpoll v1.7.0.
+// => see https://github.com/matterpoll/matterpoll/issues/562
+func upgradeTo17_2(s *Store) error {
+	var allKeys []string
+	i := 0
+	for {
+		keys, appErr := s.api.KVList(i, perPage)
+		if appErr != nil {
+			return errors.Wrap(appErr, "failed to list poll keys")
+		}
+
+		allKeys = append(allKeys, keys...)
+
+		if len(keys) < perPage {
+			break
+		}
+
+		i++
+	}
+
+	for _, k := range allKeys {
+		// Only migrate plugin keys
+		if strings.HasPrefix(k, pollPrefix) {
+			k = strings.TrimPrefix(k, pollPrefix)
+
+			poll, err := s.Poll().Get(k)
+			if err != nil {
+				s.api.LogError("Failed to get poll for migration", "error", err.Error(), "pollID", k)
+				continue
+			}
+
 			err = s.Poll().Save(poll)
 			if err != nil {
 				s.api.LogError("Failed to save poll after migration", "error", err.Error(), "pollID", k)


### PR DESCRIPTION
refs #562, #564 

## Summary

My bad, #564 doesn't resolve the issue completely.
If the poll with `{..., AnonymousCreator: false}` stored already by Matterpoll v1.7.0, `omitempty` will remove `AnonymousCreate: false` in existing data, and cause atomic transaction failure again.
To avoid atomic transaction failure related `AnonymousCreator` setting, we have to migrate existing data when upgrading.