### PR TITLE
Fix flaky TestHandleVote and TestHandleResetVotes

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -428,12 +428,9 @@ func (p *MatterpollPlugin) handleVote(vars map[string]string, request *model.Pos
 // caller does not have to wait on the permission check and the websocket event. The
 // goroutine is tracked in p.backgroundJobs so it can be waited on.
 func (p *MatterpollPlugin) publishPollMetadataAsync(poll *poll.Poll, userID string) {
-	p.backgroundJobs.Add(1)
-
-	go func() {
-		defer p.backgroundJobs.Done()
+	p.backgroundJobs.Go(func() {
 		p.publishPollMetadata(poll, userID)
-	}()
+	})
 }
 
 func (p *MatterpollPlugin) publishPollMetadata(poll *poll.Poll, userID string) {

--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -386,7 +386,7 @@ func (p *MatterpollPlugin) handleVote(vars map[string]string, request *model.Pos
 		return &i18n.LocalizeConfig{DefaultMessage: commandErrorGeneric}, nil, errors.Wrap(err, "failed to save poll")
 	}
 
-	go p.publishPollMetadata(poll, userID)
+	p.publishPollMetadataAsync(poll, userID)
 
 	post := &model.Post{}
 	model.ParseMessageAttachment(post, poll.ToPostActions(p.bundle, root.Manifest.Id, displayName))
@@ -422,6 +422,18 @@ func (p *MatterpollPlugin) handleVote(vars map[string]string, request *model.Pos
 		return &i18n.LocalizeConfig{DefaultMessage: responseVoteUpdated}, post, nil
 	}
 	return &i18n.LocalizeConfig{DefaultMessage: responseVoteCounted}, post, nil
+}
+
+// publishPollMetadataAsync publishes the poll metadata in the background, so that the
+// caller does not have to wait on the permission check and the websocket event. The
+// goroutine is tracked in p.backgroundJobs so it can be waited on.
+func (p *MatterpollPlugin) publishPollMetadataAsync(poll *poll.Poll, userID string) {
+	p.backgroundJobs.Add(1)
+
+	go func() {
+		defer p.backgroundJobs.Done()
+		p.publishPollMetadata(poll, userID)
+	}()
 }
 
 func (p *MatterpollPlugin) publishPollMetadata(poll *poll.Poll, userID string) {
@@ -464,7 +476,7 @@ func (p *MatterpollPlugin) handleResetVotes(vars map[string]string, request *mod
 		return &i18n.LocalizeConfig{DefaultMessage: commandErrorGeneric}, nil, errors.Wrap(err, "failed to save poll")
 	}
 
-	go p.publishPollMetadata(poll, userID)
+	p.publishPollMetadataAsync(poll, userID)
 
 	post := &model.Post{}
 	model.ParseMessageAttachment(post, poll.ToPostActions(p.bundle, root.Manifest.Id, displayName))

--- a/server/plugin/api_test.go
+++ b/server/plugin/api_test.go
@@ -1085,6 +1085,9 @@ func TestHandleVote(t *testing.T) {
 				r.Header.Add("Mattermost-User-ID", model.NewId())
 			}
 			p.ServeHTTP(nil, w, r)
+			// handleVote/handleResetVotes publish the poll metadata in the background;
+			// wait for that to finish before the deferred mock assertions run.
+			p.backgroundJobs.Wait()
 
 			result := w.Result()
 			require.NotNil(t, result)
@@ -1390,6 +1393,9 @@ func TestHandleResetVotes(t *testing.T) {
 				r.Header.Add("Mattermost-User-ID", model.NewId())
 			}
 			p.ServeHTTP(nil, w, r)
+			// handleVote/handleResetVotes publish the poll metadata in the background;
+			// wait for that to finish before the deferred mock assertions run.
+			p.backgroundJobs.Wait()
 
 			result := w.Result()
 			require.NotNil(t, result)

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -31,6 +31,10 @@ type MatterpollPlugin struct {
 	// activated is used to track whether or not OnActivate has initialized the plugin state.
 	activated bool
 
+	// backgroundJobs tracks goroutines started to do work outside the lifetime of the
+	// request that spawned them, so that OnDeactivate (and tests) can wait for them.
+	backgroundJobs sync.WaitGroup
+
 	// configurationLock synchronizes access to the configuration.
 	configurationLock sync.RWMutex
 
@@ -117,9 +121,10 @@ func (p *MatterpollPlugin) OnActivate() error {
 	return nil
 }
 
-// OnDeactivate marks the plugin as deactivated
+// OnDeactivate marks the plugin as deactivated and waits for any background jobs to finish
 func (p *MatterpollPlugin) OnDeactivate() error {
 	p.setActivated(false)
+	p.backgroundJobs.Wait()
 
 	return nil
 }


### PR DESCRIPTION
## The flake

`handleVote` and `handleResetVotes` published the poll metadata with a bare fire-and-forget goroutine:

```go
go p.publishPollMetadata(poll, userID)
```

Nothing tracked that goroutine, so its `p.API.PublishWebSocketEvent("has_voted", ...)` call raced the `defer api.AssertExpectations(t)` in the table-driven subtests of `TestHandleVote` and `TestHandleResetVotes`. Whenever the assertion won the race, the subtest failed with:

```
FAIL: PublishWebSocketEvent(string,map[string]interface {},*model.WebsocketBroadcast)
    at: [server/plugin/api_test.go:885 server/plugin/api_test.go:1057]
FAIL: 8 out of 9 expectation(s) were met.
    The code you are testing needs to make 1 more call(s).
```

On this machine that was **4–5 failing subtests per `go test ./...` run** on unmodified `master`.

## The fix

Track the goroutine in a `backgroundJobs` `sync.WaitGroup` on `MatterpollPlugin`, and spawn it through a new `publishPollMetadataAsync` helper rather than inline at each call site. The two affected tests wait on that group after `ServeHTTP` returns — before the deferred mock assertions run.

`OnDeactivate` waits on the group too, so the plugin no longer leaves the publish goroutine running past deactivation.

The publish stays asynchronous, so request latency is unchanged — this only makes the existing background work observable.

## Verification

| Check | Result |
| --- | --- |
| `./server/plugin/...`, 15 consecutive runs with `-count=1` | 15/15 clean |
| `./...`, 5 consecutive runs with `-count=1` | 5/5 clean |
| `go test -race -count=3 ./...` | clean |
| `go build ./...`, `go vet ./...` | clean |
| `go tool golangci-lint run ./...` | 0 issues |

For comparison, the same 5-run loop on unmodified `master` fails in every run.

## Note

Found while working on #664 (the Go 1.27 / dependency upgrade), where this flake was tripping CI runs. It is entirely independent of that PR — this branch is cut from `master` and touches no dependency or tooling files, so the two can merge in either order.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5o3V3KGruMEexEb8oiDvu)_