### PR TITLE
Fix PostType crash caused by Babel 8's automatic JSX runtime

### DIFF
--- a/webapp/babel.config.js
+++ b/webapp/babel.config.js
@@ -18,6 +18,7 @@ const config = {
             debug: false,
             shippedProposals: true,
         }],
+
         // The plugin's webpack config externalizes `react` to the host webapp's
         // global React instance; the default "automatic" runtime would instead
         // bundle this project's own react/jsx-(dev-)runtime copy, which then

--- a/webapp/babel.config.js
+++ b/webapp/babel.config.js
@@ -18,7 +18,11 @@ const config = {
             debug: false,
             shippedProposals: true,
         }],
-        '@babel/preset-react',
+        // The plugin's webpack config externalizes `react` to the host webapp's
+        // global React instance; the default "automatic" runtime would instead
+        // bundle this project's own react/jsx-(dev-)runtime copy, which then
+        // holds internal state that doesn't match the host's React instance.
+        ['@babel/preset-react', {runtime: 'classic'}],
 
         // Babel 8 removed `allExtensions`/`isTSX`; the preset now decides whether to
         // parse JSX from the file extension, which is what this project wants.


### PR DESCRIPTION
## Summary
- Babel 8's `@babel/preset-react` defaults `runtime` to `"automatic"`, which compiles JSX to imports from `react/jsx-(dev-)runtime` instead of `React.createElement`.
- `webpack.config.js` only externalizes `react`/`react-dom` to the host webapp's global React instance, so the automatic runtime caused the plugin bundle to include its own copy of `react/jsx-dev-runtime`, whose internal state didn't match the host's actual React instance.
- This crashed `PostType` (matterpoll's poll post renderer) with `Cannot read properties of undefined (reading 'recentlyCreatedOwnerStacks')` whenever a poll was rendered in the channel view.
- Fix: pin `@babel/preset-react`'s `runtime` back to `'classic'` in `webapp/babel.config.js`, restoring the pre-Babel-8 default and compiling JSX to `React.createElement`, which correctly shares the host's single React instance.

## Test plan
- [x] `npm run check-types` passes
- [x] `npx jest` — 69/69 tests pass
- [x] `npm run build` (production) and debug builds succeed
- [x] Verified the emitted `dist/main.js` no longer references `jsx-dev-runtime`/`jsx-runtime` and uses `React.createElement`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated React compilation settings to use the classic runtime.
  * No visible user-facing changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->