### PR TITLE
Remove nightly schedule trigger from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: ci
 on:
-  schedule:
-    - cron: "0 0 * * *"
   push:
     branches:
       - master


### PR DESCRIPTION
## Summary
- Removes the `schedule: cron` trigger from `.github/workflows/ci.yml`, matching the fix applied to mattermost-plugin-starter-template (#248 there)
- The schedule trigger causes GitHub to disable the entire workflow after 60 days of inactivity in derived repos, silently taking `pull_request` checks with it

## Test plan
- [x] Confirmed `ci.yml` no longer schedules a nightly cron run
- [x] CI passes on this PR's `pull_request` trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)