### PR TITLE
Remove static version from plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,6 @@
     "homepage_url": "https://github.com/matterpoll/matterpoll",
     "support_url": "https://github.com/matterpoll/matterpoll/issues",
     "icon_path": "assets/logo_dark.svg",
-    "version": "1.8.0",
     "min_server_version": "8.1.0",
     "server": {
         "executables": {


### PR DESCRIPTION
## Summary
- The v1.9.0 release bundle was published as `com.github.matterpoll.matterpoll-1.8.0.tar.gz` because `plugin.json`'s `version` field was never bumped before tagging — `make patch`/`minor`/`major` only advance the git tag, they don't touch `plugin.json`.
- `build/manifest/main.go` (from the recent starter-template realignment, #668) already auto-derives the version from the current git tag when `plugin.json`'s `version` is empty, so removing the static value lets the build tooling always match the tag.

## Test plan
- [x] Built `build/bin/manifest` with `BuildTagCurrent=v1.9.0` against `plugin.json` with no `version` field — `manifest version` correctly outputs `1.9.0`.
- [x] `manifest check` passes with `version` omitted (validation only checks format when non-empty).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the explicit version setting from the plugin configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->